### PR TITLE
feat: expand content and engine for replayability

### DIFF
--- a/content/cards/accept_technical_debt_amnesty-v1.json
+++ b/content/cards/accept_technical_debt_amnesty-v1.json
@@ -1,0 +1,33 @@
+{
+  "id": "accept_technical_debt_amnesty",
+  "version": 1,
+  "name": "Accept Technical Debt Amnesty",
+  "description": "Declare a moratorium on debt discussions to boost morale, but the debt doesn't go away",
+  "flavor_text": "We'll deal with it next quarter. Definitely next quarter.",
+  "usage_limit": 1,
+  "style_tags": ["short-term", "morale", "risky"],
+  "score_changes": [
+    {
+      "score_id": "team_morale",
+      "delta": 8
+    },
+    {
+      "score_id": "delivery_confidence",
+      "delta": 3
+    },
+    {
+      "score_id": "maintainability",
+      "delta": -7
+    },
+    {
+      "score_id": "domain_clarity",
+      "delta": -3
+    }
+  ],
+  "delayed_effect_refs": [
+    {
+      "id": "technical_debt_accumulates",
+      "version": 1
+    }
+  ]
+}

--- a/content/cards/cancel_feature_sprint_for_refactoring-v1.json
+++ b/content/cards/cancel_feature_sprint_for_refactoring-v1.json
@@ -1,0 +1,33 @@
+{
+  "id": "cancel_feature_sprint_for_refactoring",
+  "version": 1,
+  "name": "Cancel Feature Sprint for Refactoring",
+  "description": "Redirect an entire sprint to refactoring work, angering product stakeholders",
+  "flavor_text": "The VP Product's eye just twitched",
+  "usage_limit": 1,
+  "style_tags": ["architecture", "long-term", "unpopular"],
+  "score_changes": [
+    {
+      "score_id": "maintainability",
+      "delta": 8
+    },
+    {
+      "score_id": "domain_clarity",
+      "delta": 4
+    },
+    {
+      "score_id": "delivery_confidence",
+      "delta": -6
+    },
+    {
+      "score_id": "team_morale",
+      "delta": 2
+    }
+  ],
+  "delayed_effect_refs": [
+    {
+      "id": "refactoring_payoff",
+      "version": 1
+    }
+  ]
+}

--- a/content/cards/emergency_architecture_review-v1.json
+++ b/content/cards/emergency_architecture_review-v1.json
@@ -1,0 +1,33 @@
+{
+  "id": "emergency_architecture_review",
+  "version": 1,
+  "name": "Emergency Architecture Review",
+  "description": "Halt all feature work for a focused architecture assessment and realignment",
+  "flavor_text": "Everyone stop. We need to look at this diagram again.",
+  "usage_limit": 1,
+  "style_tags": ["architecture", "strategic", "defensive"],
+  "score_changes": [
+    {
+      "score_id": "domain_clarity",
+      "delta": 5
+    },
+    {
+      "score_id": "maintainability",
+      "delta": 4
+    },
+    {
+      "score_id": "delivery_confidence",
+      "delta": -5
+    },
+    {
+      "score_id": "budget",
+      "delta": -3
+    }
+  ],
+  "delayed_effect_refs": [
+    {
+      "id": "improved_clarity",
+      "version": 1
+    }
+  ]
+}

--- a/content/cards/platform_team_formation-v1.json
+++ b/content/cards/platform_team_formation-v1.json
@@ -1,0 +1,29 @@
+{
+  "id": "platform_team_formation",
+  "version": 1,
+  "name": "Form Platform Team",
+  "description": "Create a dedicated platform team to build shared infrastructure, expensive now but pays off later",
+  "flavor_text": "Another team? In this economy?",
+  "usage_limit": 1,
+  "style_tags": ["strategic", "long-term", "architecture"],
+  "score_changes": [
+    {
+      "score_id": "delivery_confidence",
+      "delta": 2
+    },
+    {
+      "score_id": "budget",
+      "delta": -6
+    },
+    {
+      "score_id": "team_morale",
+      "delta": -2
+    }
+  ],
+  "delayed_effect_refs": [
+    {
+      "id": "platform_maturity",
+      "version": 1
+    }
+  ]
+}

--- a/content/cards/propose_microservice_extraction-v1.json
+++ b/content/cards/propose_microservice_extraction-v1.json
@@ -1,0 +1,34 @@
+{
+  "id": "propose_microservice_extraction",
+  "version": 1,
+  "name": "Propose Microservice Extraction",
+  "description": "Split a core module into its own service to improve domain clarity, at the cost of immediate delivery disruption",
+  "flavor_text": "One monolith becomes two problems. But better problems.",
+  "usage_limit": 2,
+  "cooldown_turns": 3,
+  "style_tags": ["architecture", "boundary", "risky"],
+  "score_changes": [
+    {
+      "score_id": "domain_clarity",
+      "delta": 6
+    },
+    {
+      "score_id": "delivery_confidence",
+      "delta": -4
+    },
+    {
+      "score_id": "budget",
+      "delta": -5
+    },
+    {
+      "score_id": "maintainability",
+      "delta": 3
+    }
+  ],
+  "delayed_effect_refs": [
+    {
+      "id": "integration_complexity_emerges",
+      "version": 1
+    }
+  ]
+}

--- a/content/cards/propose_unified_domain_model-v1.json
+++ b/content/cards/propose_unified_domain_model-v1.json
@@ -1,0 +1,33 @@
+{
+  "id": "propose_unified_domain_model",
+  "version": 1,
+  "name": "Propose Unified Domain Model",
+  "description": "Design a shared domain model that reconciles both companies' conceptual frameworks",
+  "flavor_text": "Their 'Customer' and our 'Client' are the same thing. Mostly.",
+  "usage_limit": 1,
+  "style_tags": ["architecture", "boundary", "strategic"],
+  "score_changes": [
+    {
+      "score_id": "domain_clarity",
+      "delta": 8
+    },
+    {
+      "score_id": "maintainability",
+      "delta": 4
+    },
+    {
+      "score_id": "delivery_confidence",
+      "delta": -5
+    },
+    {
+      "score_id": "budget",
+      "delta": -4
+    }
+  ],
+  "delayed_effect_refs": [
+    {
+      "id": "unified_model_clarity",
+      "version": 1
+    }
+  ]
+}

--- a/content/cards/publish_engineering_blog-v1.json
+++ b/content/cards/publish_engineering_blog-v1.json
@@ -1,0 +1,25 @@
+{
+  "id": "publish_engineering_blog",
+  "version": 1,
+  "name": "Publish Engineering Blog Post",
+  "description": "Share your team's technical story publicly, boosting morale and external reputation",
+  "flavor_text": "Our thought leadership pipeline is deploying to production",
+  "usage_limit": 2,
+  "cooldown_turns": 3,
+  "style_tags": ["morale", "strategic", "external"],
+  "score_changes": [
+    {
+      "score_id": "team_morale",
+      "delta": 4
+    },
+    {
+      "score_id": "user_trust",
+      "delta": 3
+    },
+    {
+      "score_id": "delivery_confidence",
+      "delta": -2
+    }
+  ],
+  "delayed_effect_refs": []
+}

--- a/content/cards/run_integration_workshop-v1.json
+++ b/content/cards/run_integration_workshop-v1.json
@@ -1,0 +1,34 @@
+{
+  "id": "run_integration_workshop",
+  "version": 1,
+  "name": "Run Integration Workshop",
+  "description": "Bring teams from both companies together to map integration points and build relationships",
+  "flavor_text": "Day one: awkward introductions. Day two: shared whiteboards. Day three: inside jokes.",
+  "usage_limit": 2,
+  "cooldown_turns": 3,
+  "style_tags": ["process", "morale", "strategic"],
+  "score_changes": [
+    {
+      "score_id": "domain_clarity",
+      "delta": 5
+    },
+    {
+      "score_id": "team_morale",
+      "delta": 6
+    },
+    {
+      "score_id": "delivery_confidence",
+      "delta": -3
+    },
+    {
+      "score_id": "budget",
+      "delta": -3
+    }
+  ],
+  "delayed_effect_refs": [
+    {
+      "id": "culture_alignment_progress",
+      "version": 1
+    }
+  ]
+}

--- a/content/cards/shadow_it_consolidation-v1.json
+++ b/content/cards/shadow_it_consolidation-v1.json
@@ -1,0 +1,33 @@
+{
+  "id": "shadow_it_consolidation",
+  "version": 1,
+  "name": "Shadow IT Consolidation",
+  "description": "Bring rogue tools and unofficial services under official architecture governance",
+  "flavor_text": "Yes, we know about the spreadsheet running your production pipeline",
+  "usage_limit": 1,
+  "style_tags": ["architecture", "governance", "unpopular"],
+  "score_changes": [
+    {
+      "score_id": "maintainability",
+      "delta": 5
+    },
+    {
+      "score_id": "domain_clarity",
+      "delta": 4
+    },
+    {
+      "score_id": "team_morale",
+      "delta": -4
+    },
+    {
+      "score_id": "delivery_confidence",
+      "delta": -2
+    }
+  ],
+  "delayed_effect_refs": [
+    {
+      "id": "boundaries_clarify",
+      "version": 1
+    }
+  ]
+}

--- a/content/cards/sunset_duplicate_system-v1.json
+++ b/content/cards/sunset_duplicate_system-v1.json
@@ -1,0 +1,38 @@
+{
+  "id": "sunset_duplicate_system",
+  "version": 1,
+  "name": "Sunset Duplicate System",
+  "description": "Decommission one of the redundant systems and migrate users to the surviving one",
+  "flavor_text": "One must go. Choosing which one is the hard part.",
+  "usage_limit": 2,
+  "cooldown_turns": 3,
+  "style_tags": ["architecture", "long-term", "unpopular"],
+  "score_changes": [
+    {
+      "score_id": "maintainability",
+      "delta": 6
+    },
+    {
+      "score_id": "budget",
+      "delta": 5
+    },
+    {
+      "score_id": "team_morale",
+      "delta": -4
+    },
+    {
+      "score_id": "user_trust",
+      "delta": -3
+    },
+    {
+      "score_id": "delivery_confidence",
+      "delta": -3
+    }
+  ],
+  "delayed_effect_refs": [
+    {
+      "id": "refactoring_payoff",
+      "version": 1
+    }
+  ]
+}

--- a/content/cards/sunset_legacy_feature-v1.json
+++ b/content/cards/sunset_legacy_feature-v1.json
@@ -1,0 +1,34 @@
+{
+  "id": "sunset_legacy_feature",
+  "version": 1,
+  "name": "Sunset Legacy Feature",
+  "description": "Remove a beloved but unmaintainable feature that's dragging down the system",
+  "flavor_text": "Nobody uses it. Except the three people who will be very, very loud about it.",
+  "usage_limit": 2,
+  "cooldown_turns": 3,
+  "style_tags": ["architecture", "unpopular", "long-term"],
+  "score_changes": [
+    {
+      "score_id": "maintainability",
+      "delta": 7
+    },
+    {
+      "score_id": "domain_clarity",
+      "delta": 3
+    },
+    {
+      "score_id": "user_trust",
+      "delta": -5
+    },
+    {
+      "score_id": "team_morale",
+      "delta": -2
+    }
+  ],
+  "delayed_effect_refs": [
+    {
+      "id": "refactoring_payoff",
+      "version": 1
+    }
+  ]
+}

--- a/content/challenge-modifiers/budget_crisis-v1.json
+++ b/content/challenge-modifiers/budget_crisis-v1.json
@@ -1,0 +1,12 @@
+{
+  "id": "budget_crisis",
+  "version": 1,
+  "name": "Budget Crisis",
+  "description": "The CFO has cut funding. Budget starts critically low and every spend is scrutinized",
+  "flavor_text": "Apparently 'technical investment' isn't in this quarter's vocabulary",
+  "score_adjustments": {
+    "budget": -20,
+    "delivery_confidence": -5,
+    "team_morale": -5
+  }
+}

--- a/content/challenge-modifiers/hard_mode-v1.json
+++ b/content/challenge-modifiers/hard_mode-v1.json
@@ -1,0 +1,15 @@
+{
+  "id": "hard_mode",
+  "version": 1,
+  "name": "Hard Mode",
+  "description": "All scores start significantly lower. Every decision matters more",
+  "flavor_text": "The board already lost confidence before you walked in",
+  "score_adjustments": {
+    "domain_clarity": -10,
+    "maintainability": -10,
+    "delivery_confidence": -10,
+    "team_morale": -10,
+    "user_trust": -10,
+    "budget": -10
+  }
+}

--- a/content/challenge-modifiers/hard_mode-v1.json
+++ b/content/challenge-modifiers/hard_mode-v1.json
@@ -5,11 +5,11 @@
   "description": "All scores start significantly lower. Every decision matters more",
   "flavor_text": "The board already lost confidence before you walked in",
   "score_adjustments": {
-    "domain_clarity": -10,
-    "maintainability": -10,
-    "delivery_confidence": -10,
-    "team_morale": -10,
-    "user_trust": -10,
-    "budget": -10
+    "domain_clarity": -7,
+    "maintainability": -7,
+    "delivery_confidence": -7,
+    "team_morale": -7,
+    "user_trust": -7,
+    "budget": -7
   }
 }

--- a/content/challenge-modifiers/speed_run-v1.json
+++ b/content/challenge-modifiers/speed_run-v1.json
@@ -1,0 +1,8 @@
+{
+  "id": "speed_run",
+  "version": 1,
+  "name": "Speed Run",
+  "description": "Two fewer turns to achieve your goals. No room for wasted actions",
+  "flavor_text": "The deadline was moved up. Again",
+  "turn_adjustment": -2
+}

--- a/content/challenge-modifiers/stakeholder_revolt-v1.json
+++ b/content/challenge-modifiers/stakeholder_revolt-v1.json
@@ -4,5 +4,9 @@
   "name": "Stakeholder Revolt",
   "description": "All stakeholders start deeply dissatisfied. Earn their trust from scratch",
   "flavor_text": "The last architect left under... mysterious circumstances",
+  "score_adjustments": {
+    "team_morale": -10,
+    "delivery_confidence": -5
+  },
   "stakeholder_satisfaction_override": 30
 }

--- a/content/challenge-modifiers/stakeholder_revolt-v1.json
+++ b/content/challenge-modifiers/stakeholder_revolt-v1.json
@@ -1,0 +1,8 @@
+{
+  "id": "stakeholder_revolt",
+  "version": 1,
+  "name": "Stakeholder Revolt",
+  "description": "All stakeholders start deeply dissatisfied. Earn their trust from scratch",
+  "flavor_text": "The last architect left under... mysterious circumstances",
+  "stakeholder_satisfaction_override": 30
+}

--- a/content/classes/boundary_mage-v1.json
+++ b/content/classes/boundary_mage-v1.json
@@ -3,5 +3,6 @@
   "version": 1,
   "name": "Boundary Mage",
   "description": "Master of domain boundaries and context mapping",
-  "flavor_text": "You see the invisible lines that separate one domain from another"
+  "flavor_text": "You see the invisible lines that separate one domain from another",
+  "score_affinity": "domain_clarity"
 }

--- a/content/classes/delivery_rogue-v1.json
+++ b/content/classes/delivery_rogue-v1.json
@@ -3,5 +3,6 @@
   "version": 1,
   "name": "Delivery Rogue",
   "description": "Swift architect who balances speed with sustainable design",
-  "flavor_text": "You ship features fast while dodging the traps of technical debt"
+  "flavor_text": "You ship features fast while dodging the traps of technical debt",
+  "score_affinity": "delivery_confidence"
 }

--- a/content/classes/legacy_ranger-v1.json
+++ b/content/classes/legacy_ranger-v1.json
@@ -3,5 +3,6 @@
   "version": 1,
   "name": "Legacy Ranger",
   "description": "Expert navigator of ancient codebases and forgotten dependencies",
-  "flavor_text": "You know where the bodies are buried in the old code"
+  "flavor_text": "You know where the bodies are buried in the old code",
+  "score_affinity": "maintainability"
 }

--- a/content/classes/reliability_cleric-v1.json
+++ b/content/classes/reliability_cleric-v1.json
@@ -3,5 +3,6 @@
   "version": 1,
   "name": "Reliability Cleric",
   "description": "Guardian of system stability and operational excellence",
-  "flavor_text": "You heal production incidents before they become disasters"
+  "flavor_text": "You heal production incidents before they become disasters",
+  "score_affinity": "user_trust"
 }

--- a/content/classes/stakeholder_bard-v1.json
+++ b/content/classes/stakeholder_bard-v1.json
@@ -3,5 +3,6 @@
   "version": 1,
   "name": "Stakeholder Bard",
   "description": "Diplomat who speaks the language of business and engineering",
-  "flavor_text": "You translate between business needs and technical reality"
+  "flavor_text": "You translate between business needs and technical reality",
+  "score_affinity": "team_morale"
 }

--- a/content/delayed-effects/burnout_recovery_stalls-v1.json
+++ b/content/delayed-effects/burnout_recovery_stalls-v1.json
@@ -1,0 +1,17 @@
+{
+  "id": "burnout_recovery_stalls",
+  "version": 1,
+  "name": "Burnout Recovery Stalls",
+  "description": "Exhausted team members struggle to regain productivity",
+  "turns_until_resolution": 3,
+  "score_changes": [
+    {
+      "score_id": "team_morale",
+      "delta": -6
+    },
+    {
+      "score_id": "maintainability",
+      "delta": -4
+    }
+  ]
+}

--- a/content/delayed-effects/compliance_clarity_spreads-v1.json
+++ b/content/delayed-effects/compliance_clarity_spreads-v1.json
@@ -1,0 +1,17 @@
+{
+  "id": "compliance_clarity_spreads",
+  "version": 1,
+  "name": "Compliance Clarity Spreads",
+  "description": "A clean audit finding gives the team confidence to document more boundaries",
+  "turns_until_resolution": 2,
+  "score_changes": [
+    {
+      "score_id": "domain_clarity",
+      "delta": 5
+    },
+    {
+      "score_id": "user_trust",
+      "delta": 3
+    }
+  ]
+}

--- a/content/delayed-effects/culture_alignment_progress-v1.json
+++ b/content/delayed-effects/culture_alignment_progress-v1.json
@@ -1,0 +1,17 @@
+{
+  "id": "culture_alignment_progress",
+  "version": 1,
+  "name": "Culture Alignment Progress",
+  "description": "The two engineering cultures begin finding common ground",
+  "turns_until_resolution": 2,
+  "score_changes": [
+    {
+      "score_id": "team_morale",
+      "delta": 6
+    },
+    {
+      "score_id": "delivery_confidence",
+      "delta": 3
+    }
+  ]
+}

--- a/content/delayed-effects/demo_momentum-v1.json
+++ b/content/delayed-effects/demo_momentum-v1.json
@@ -1,0 +1,17 @@
+{
+  "id": "demo_momentum",
+  "version": 1,
+  "name": "Demo Momentum",
+  "description": "A successful demo energizes the team and builds stakeholder confidence",
+  "turns_until_resolution": 2,
+  "score_changes": [
+    {
+      "score_id": "delivery_confidence",
+      "delta": 5
+    },
+    {
+      "score_id": "team_morale",
+      "delta": 4
+    }
+  ]
+}

--- a/content/delayed-effects/duplicate_system_costs-v1.json
+++ b/content/delayed-effects/duplicate_system_costs-v1.json
@@ -1,0 +1,17 @@
+{
+  "id": "duplicate_system_costs",
+  "version": 1,
+  "name": "Duplicate System Costs",
+  "description": "Running two versions of the same system doubles operational overhead",
+  "turns_until_resolution": 2,
+  "score_changes": [
+    {
+      "score_id": "budget",
+      "delta": -6
+    },
+    {
+      "score_id": "maintainability",
+      "delta": -3
+    }
+  ]
+}

--- a/content/delayed-effects/investor_confidence_boost-v1.json
+++ b/content/delayed-effects/investor_confidence_boost-v1.json
@@ -1,0 +1,17 @@
+{
+  "id": "investor_confidence_boost",
+  "version": 1,
+  "name": "Investor Confidence Boost",
+  "description": "Positive board presentation leads to increased investment appetite",
+  "turns_until_resolution": 2,
+  "score_changes": [
+    {
+      "score_id": "budget",
+      "delta": 6
+    },
+    {
+      "score_id": "delivery_confidence",
+      "delta": 3
+    }
+  ]
+}

--- a/content/delayed-effects/open_source_community_grows-v1.json
+++ b/content/delayed-effects/open_source_community_grows-v1.json
@@ -1,0 +1,17 @@
+{
+  "id": "open_source_community_grows",
+  "version": 1,
+  "name": "Open Source Community Grows",
+  "description": "External contributors start submitting improvements to the extracted module",
+  "turns_until_resolution": 2,
+  "score_changes": [
+    {
+      "score_id": "maintainability",
+      "delta": 4
+    },
+    {
+      "score_id": "team_morale",
+      "delta": 3
+    }
+  ]
+}

--- a/content/delayed-effects/partnership_integration_costs-v1.json
+++ b/content/delayed-effects/partnership_integration_costs-v1.json
@@ -1,0 +1,17 @@
+{
+  "id": "partnership_integration_costs",
+  "version": 1,
+  "name": "Partnership Integration Costs",
+  "description": "Integrating with a vendor partner requires ongoing engineering effort",
+  "turns_until_resolution": 2,
+  "score_changes": [
+    {
+      "score_id": "budget",
+      "delta": -5
+    },
+    {
+      "score_id": "delivery_confidence",
+      "delta": -3
+    }
+  ]
+}

--- a/content/delayed-effects/platform_maturity-v1.json
+++ b/content/delayed-effects/platform_maturity-v1.json
@@ -1,0 +1,21 @@
+{
+  "id": "platform_maturity",
+  "version": 1,
+  "name": "Platform Maturity",
+  "description": "The platform team's shared infrastructure starts paying dividends",
+  "turns_until_resolution": 3,
+  "score_changes": [
+    {
+      "score_id": "maintainability",
+      "delta": 6
+    },
+    {
+      "score_id": "delivery_confidence",
+      "delta": 5
+    },
+    {
+      "score_id": "team_morale",
+      "delta": 3
+    }
+  ]
+}

--- a/content/delayed-effects/unified_model_clarity-v1.json
+++ b/content/delayed-effects/unified_model_clarity-v1.json
@@ -1,0 +1,17 @@
+{
+  "id": "unified_model_clarity",
+  "version": 1,
+  "name": "Unified Model Clarity",
+  "description": "The two domain models start converging into a shared understanding",
+  "turns_until_resolution": 3,
+  "score_changes": [
+    {
+      "score_id": "domain_clarity",
+      "delta": 7
+    },
+    {
+      "score_id": "maintainability",
+      "delta": 4
+    }
+  ]
+}

--- a/content/events/acquisition_rumor-v1.json
+++ b/content/events/acquisition_rumor-v1.json
@@ -1,0 +1,23 @@
+{
+  "id": "acquisition_rumor",
+  "version": 1,
+  "name": "Acquisition Rumor",
+  "description": "Rumors of a potential acquisition create excitement about budget but anxiety about job security",
+  "flavor_text": "The Slack rumor mill is producing at peak capacity",
+  "occurrence_weight": 3,
+  "score_changes": [
+    {
+      "score_id": "budget",
+      "delta": 5
+    },
+    {
+      "score_id": "team_morale",
+      "delta": -6
+    },
+    {
+      "score_id": "delivery_confidence",
+      "delta": -3
+    }
+  ],
+  "delayed_effect_refs": []
+}

--- a/content/events/architecture_award_nomination-v1.json
+++ b/content/events/architecture_award_nomination-v1.json
@@ -1,0 +1,24 @@
+{
+  "id": "architecture_award_nomination",
+  "version": 1,
+  "name": "Architecture Award Nomination",
+  "description": "The team's architectural improvements earn recognition at an industry conference",
+  "flavor_text": "Someone actually read your architecture decision records",
+  "occurrence_weight": 3,
+  "trigger_condition_description": "Domain clarity > 70",
+  "score_changes": [
+    {
+      "score_id": "team_morale",
+      "delta": 8
+    },
+    {
+      "score_id": "user_trust",
+      "delta": 4
+    },
+    {
+      "score_id": "budget",
+      "delta": 3
+    }
+  ],
+  "delayed_effect_refs": []
+}

--- a/content/events/auditor_finds_clean_module-v1.json
+++ b/content/events/auditor_finds_clean_module-v1.json
@@ -1,0 +1,29 @@
+{
+  "id": "auditor_finds_clean_module",
+  "version": 1,
+  "name": "Auditor Finds Clean Module",
+  "description": "An external auditor highlights a well-structured module as an example of good practice",
+  "flavor_text": "The auditor smiled. Nobody knew auditors could smile.",
+  "occurrence_weight": 4,
+  "trigger_condition_description": "Domain clarity > 50",
+  "score_changes": [
+    {
+      "score_id": "domain_clarity",
+      "delta": 4
+    },
+    {
+      "score_id": "user_trust",
+      "delta": 6
+    },
+    {
+      "score_id": "team_morale",
+      "delta": 5
+    }
+  ],
+  "delayed_effect_refs": [
+    {
+      "id": "compliance_clarity_spreads",
+      "version": 1
+    }
+  ]
+}

--- a/content/events/cross_team_hackathon-v1.json
+++ b/content/events/cross_team_hackathon-v1.json
@@ -1,0 +1,28 @@
+{
+  "id": "cross_team_hackathon",
+  "version": 1,
+  "name": "Cross-Team Hackathon",
+  "description": "Teams collaborate on experimental projects, discovering unexpected synergies",
+  "flavor_text": "The best ideas came from the team that wasn't supposed to be there",
+  "occurrence_weight": 4,
+  "score_changes": [
+    {
+      "score_id": "team_morale",
+      "delta": 6
+    },
+    {
+      "score_id": "domain_clarity",
+      "delta": 4
+    },
+    {
+      "score_id": "delivery_confidence",
+      "delta": -2
+    }
+  ],
+  "delayed_effect_refs": [
+    {
+      "id": "team_energized",
+      "version": 1
+    }
+  ]
+}

--- a/content/events/culture_clash_incident-v1.json
+++ b/content/events/culture_clash_incident-v1.json
@@ -1,0 +1,23 @@
+{
+  "id": "culture_clash_incident",
+  "version": 1,
+  "name": "Culture Clash Incident",
+  "description": "A heated disagreement between teams from the two companies derails a planning meeting",
+  "flavor_text": "We do standups differently here. This is a hill someone is willing to die on.",
+  "occurrence_weight": 5,
+  "score_changes": [
+    {
+      "score_id": "team_morale",
+      "delta": -7
+    },
+    {
+      "score_id": "delivery_confidence",
+      "delta": -4
+    },
+    {
+      "score_id": "domain_clarity",
+      "delta": -2
+    }
+  ],
+  "delayed_effect_refs": []
+}

--- a/content/events/duplicate_system_discovery-v1.json
+++ b/content/events/duplicate_system_discovery-v1.json
@@ -1,0 +1,28 @@
+{
+  "id": "duplicate_system_discovery",
+  "version": 1,
+  "name": "Duplicate System Discovery",
+  "description": "Teams realize both companies built the same subsystem with incompatible designs",
+  "flavor_text": "Wait, you have an order service too? And it's... different?",
+  "occurrence_weight": 5,
+  "score_changes": [
+    {
+      "score_id": "domain_clarity",
+      "delta": -5
+    },
+    {
+      "score_id": "maintainability",
+      "delta": -4
+    },
+    {
+      "score_id": "budget",
+      "delta": -3
+    }
+  ],
+  "delayed_effect_refs": [
+    {
+      "id": "duplicate_system_costs",
+      "version": 1
+    }
+  ]
+}

--- a/content/events/integration_demo_success-v1.json
+++ b/content/events/integration_demo_success-v1.json
@@ -1,0 +1,29 @@
+{
+  "id": "integration_demo_success",
+  "version": 1,
+  "name": "Integration Demo Success",
+  "description": "The first cross-system demo works flawlessly, proving the merger can succeed technically",
+  "flavor_text": "Both systems talking to each other. Nobody expected it to actually work.",
+  "occurrence_weight": 4,
+  "trigger_condition_description": "Domain clarity > 40",
+  "score_changes": [
+    {
+      "score_id": "team_morale",
+      "delta": 7
+    },
+    {
+      "score_id": "delivery_confidence",
+      "delta": 5
+    },
+    {
+      "score_id": "user_trust",
+      "delta": 4
+    }
+  ],
+  "delayed_effect_refs": [
+    {
+      "id": "demo_momentum",
+      "version": 1
+    }
+  ]
+}

--- a/content/events/investor_board_presentation-v1.json
+++ b/content/events/investor_board_presentation-v1.json
@@ -1,0 +1,28 @@
+{
+  "id": "investor_board_presentation",
+  "version": 1,
+  "name": "Investor Board Presentation",
+  "description": "The board demands a technical roadmap presentation, creating pressure but opening funding opportunities",
+  "flavor_text": "Slide 47 of your deck just says 'technical debt' with a sad face",
+  "occurrence_weight": 4,
+  "score_changes": [
+    {
+      "score_id": "delivery_confidence",
+      "delta": -4
+    },
+    {
+      "score_id": "team_morale",
+      "delta": -3
+    },
+    {
+      "score_id": "budget",
+      "delta": 4
+    }
+  ],
+  "delayed_effect_refs": [
+    {
+      "id": "investor_confidence_boost",
+      "version": 1
+    }
+  ]
+}

--- a/content/events/key_talent_poaching_attempt-v1.json
+++ b/content/events/key_talent_poaching_attempt-v1.json
@@ -1,0 +1,23 @@
+{
+  "id": "key_talent_poaching_attempt",
+  "version": 1,
+  "name": "Key Talent Poaching Attempt",
+  "description": "A competitor tries to recruit your best engineers with aggressive offers",
+  "flavor_text": "That recruiter DM wasn't very subtle",
+  "occurrence_weight": 4,
+  "score_changes": [
+    {
+      "score_id": "team_morale",
+      "delta": -5
+    },
+    {
+      "score_id": "budget",
+      "delta": -4
+    },
+    {
+      "score_id": "delivery_confidence",
+      "delta": -3
+    }
+  ],
+  "delayed_effect_refs": []
+}

--- a/content/events/legacy_system_wins_award-v1.json
+++ b/content/events/legacy_system_wins_award-v1.json
@@ -1,0 +1,24 @@
+{
+  "id": "legacy_system_wins_award",
+  "version": 1,
+  "name": "Legacy System Wins Reliability Award",
+  "description": "Despite its age, the legacy system's uptime record earns industry recognition",
+  "flavor_text": "Twenty years of uptime, held together by duct tape and prayer",
+  "occurrence_weight": 3,
+  "trigger_condition_description": "User trust > 60",
+  "score_changes": [
+    {
+      "score_id": "user_trust",
+      "delta": 7
+    },
+    {
+      "score_id": "team_morale",
+      "delta": 5
+    },
+    {
+      "score_id": "delivery_confidence",
+      "delta": -2
+    }
+  ],
+  "delayed_effect_refs": []
+}

--- a/content/events/new_cto_mandate-v1.json
+++ b/content/events/new_cto_mandate-v1.json
@@ -1,0 +1,27 @@
+{
+  "id": "new_cto_mandate",
+  "version": 1,
+  "name": "New CTO Mandate",
+  "description": "A new executive directive reshuffles priorities and demands visible architectural progress",
+  "flavor_text": "The new CTO has 'strong opinions, loosely held'. Very loosely.",
+  "occurrence_weight": 3,
+  "score_changes": [
+    {
+      "score_id": "domain_clarity",
+      "delta": -4
+    },
+    {
+      "score_id": "team_morale",
+      "delta": -4
+    },
+    {
+      "score_id": "budget",
+      "delta": 5
+    },
+    {
+      "score_id": "delivery_confidence",
+      "delta": -3
+    }
+  ],
+  "delayed_effect_refs": []
+}

--- a/content/events/open_source_contribution_viral-v1.json
+++ b/content/events/open_source_contribution_viral-v1.json
@@ -1,0 +1,28 @@
+{
+  "id": "open_source_contribution_viral",
+  "version": 1,
+  "name": "Open Source Contribution Goes Viral",
+  "description": "A team member's open source contribution gains traction, boosting the team's reputation",
+  "flavor_text": "Your GitHub stars just tripled overnight",
+  "occurrence_weight": 3,
+  "score_changes": [
+    {
+      "score_id": "team_morale",
+      "delta": 7
+    },
+    {
+      "score_id": "user_trust",
+      "delta": 5
+    },
+    {
+      "score_id": "domain_clarity",
+      "delta": 3
+    }
+  ],
+  "delayed_effect_refs": [
+    {
+      "id": "open_source_community_grows",
+      "version": 1
+    }
+  ]
+}

--- a/content/events/service_discovery_failure-v1.json
+++ b/content/events/service_discovery_failure-v1.json
@@ -1,0 +1,28 @@
+{
+  "id": "service_discovery_failure",
+  "version": 1,
+  "name": "Service Discovery Failure",
+  "description": "Services lose track of each other in the mesh, causing cascading request failures",
+  "flavor_text": "The service registry just shrugged and said 'I don't know her'",
+  "occurrence_weight": 5,
+  "score_changes": [
+    {
+      "score_id": "delivery_confidence",
+      "delta": -7
+    },
+    {
+      "score_id": "user_trust",
+      "delta": -5
+    },
+    {
+      "score_id": "domain_clarity",
+      "delta": -3
+    }
+  ],
+  "delayed_effect_refs": [
+    {
+      "id": "integration_complexity_emerges",
+      "version": 1
+    }
+  ]
+}

--- a/content/events/shadow_process_revealed-v1.json
+++ b/content/events/shadow_process_revealed-v1.json
@@ -1,0 +1,23 @@
+{
+  "id": "shadow_process_revealed",
+  "version": 1,
+  "name": "Shadow Process Revealed",
+  "description": "A critical business process was being handled by an undocumented system nobody knew about",
+  "flavor_text": "There's a cron job on someone's desktop that processes all refunds",
+  "occurrence_weight": 4,
+  "score_changes": [
+    {
+      "score_id": "domain_clarity",
+      "delta": -6
+    },
+    {
+      "score_id": "maintainability",
+      "delta": -4
+    },
+    {
+      "score_id": "user_trust",
+      "delta": -3
+    }
+  ],
+  "delayed_effect_refs": []
+}

--- a/content/events/successful_demo_day-v1.json
+++ b/content/events/successful_demo_day-v1.json
@@ -1,0 +1,28 @@
+{
+  "id": "successful_demo_day",
+  "version": 1,
+  "name": "Successful Demo Day",
+  "description": "A product demo goes surprisingly well, impressing stakeholders and energizing the team",
+  "flavor_text": "Wait, it actually works? In front of people?",
+  "occurrence_weight": 4,
+  "score_changes": [
+    {
+      "score_id": "delivery_confidence",
+      "delta": 8
+    },
+    {
+      "score_id": "user_trust",
+      "delta": 5
+    },
+    {
+      "score_id": "team_morale",
+      "delta": 4
+    }
+  ],
+  "delayed_effect_refs": [
+    {
+      "id": "demo_momentum",
+      "version": 1
+    }
+  ]
+}

--- a/content/events/team_burnout_spike-v1.json
+++ b/content/events/team_burnout_spike-v1.json
@@ -1,0 +1,29 @@
+{
+  "id": "team_burnout_spike",
+  "version": 1,
+  "name": "Team Burnout Spike",
+  "description": "Sustained pressure triggers a wave of burnout across the engineering team",
+  "flavor_text": "Three people called in sick. Two more updated their LinkedIn.",
+  "occurrence_weight": 4,
+  "trigger_condition_description": "Team morale < 30",
+  "score_changes": [
+    {
+      "score_id": "team_morale",
+      "delta": -7
+    },
+    {
+      "score_id": "delivery_confidence",
+      "delta": -5
+    },
+    {
+      "score_id": "maintainability",
+      "delta": -3
+    }
+  ],
+  "delayed_effect_refs": [
+    {
+      "id": "burnout_recovery_stalls",
+      "version": 1
+    }
+  ]
+}

--- a/content/events/vendor_partnership_offer-v1.json
+++ b/content/events/vendor_partnership_offer-v1.json
@@ -1,0 +1,28 @@
+{
+  "id": "vendor_partnership_offer",
+  "version": 1,
+  "name": "Vendor Partnership Offer",
+  "description": "A technology vendor offers a partnership that could accelerate delivery but at integration cost",
+  "flavor_text": "They say their API is 'enterprise-ready'. Famous last words.",
+  "occurrence_weight": 4,
+  "score_changes": [
+    {
+      "score_id": "budget",
+      "delta": 6
+    },
+    {
+      "score_id": "delivery_confidence",
+      "delta": 4
+    },
+    {
+      "score_id": "maintainability",
+      "delta": -3
+    }
+  ],
+  "delayed_effect_refs": [
+    {
+      "id": "partnership_integration_costs",
+      "version": 1
+    }
+  ]
+}

--- a/content/manifest.json
+++ b/content/manifest.json
@@ -29,6 +29,10 @@
     {
       "id": "startup_hypergrowth",
       "version": 1
+    },
+    {
+      "id": "merger_of_minor_chaos",
+      "version": 1
     }
   ],
   "classes": [
@@ -53,10 +57,29 @@
       "version": 1
     }
   ],
+  "challenge_modifiers": [
+    {
+      "id": "hard_mode",
+      "version": 1
+    },
+    {
+      "id": "budget_crisis",
+      "version": 1
+    },
+    {
+      "id": "stakeholder_revolt",
+      "version": 1
+    },
+    {
+      "id": "speed_run",
+      "version": 1
+    }
+  ],
   "tutorials": [],
   "content": {
     "scenarios": [
       "compliance_gauntlet-v1.json",
+      "merger_of_minor_chaos-v1.json",
       "microservice_sprawl-v1.json",
       "monolith_of_mild_despair-v1.json",
       "startup_hypergrowth-v1.json",
@@ -64,14 +87,17 @@
     ],
     "cards": [
       "absorb_emergency_production_fix-v1.json",
+      "accept_technical_debt_amnesty-v1.json",
       "add_integration_tests-v1.json",
       "align_budget_with_architecture-v1.json",
       "automate_deployment_pipeline-v1.json",
+      "cancel_feature_sprint_for_refactoring-v1.json",
       "clarify_cross_team_handoffs-v1.json",
       "coordinate_service_contracts-v1.json",
       "define_bounded_context-v1.json",
       "deprecate_legacy_api-v1.json",
       "document_ubiquitous_language-v1.json",
+      "emergency_architecture_review-v1.json",
       "establish_team_ownership-v1.json",
       "extract_shared_kernel-v1.json",
       "fortify_observability_stack-v1.json",
@@ -86,16 +112,25 @@
       "negotiate_technical_runway-v1.json",
       "pay_down_incident_backlog-v1.json",
       "pin_and_audit_dependencies-v1.json",
+      "platform_team_formation-v1.json",
+      "propose_microservice_extraction-v1.json",
+      "propose_unified_domain_model-v1.json",
+      "publish_engineering_blog-v1.json",
       "refactor_core_aggregate-v1.json",
       "refactor_module-v1.json",
+      "run_integration_workshop-v1.json",
       "run_security_audit-v1.json",
       "scale_incident_command-v1.json",
+      "shadow_it_consolidation-v1.json",
       "ship_quick_fix-v1.json",
-      "spike_on_migration_strategy-v1.json"
+      "spike_on_migration_strategy-v1.json",
+      "sunset_duplicate_system-v1.json",
+      "sunset_legacy_feature-v1.json"
     ],
     "stakeholders": [
       "cfo-v1.json",
       "cto-v1.json",
+      "integration_program_manager-v1.json",
       "lead_developer-v1.json",
       "operations_manager-v1.json",
       "security_officer-v1.json",
@@ -104,24 +139,37 @@
     ],
     "stakeholder_reaction_rules": [
       "cfo_alarmed_by_overspending-v1.json",
+      "cfo_appreciates_cost_efficiency-v1.json",
       "cfo_cuts_spending_when_budget_low-v1.json",
       "cfo_rewards_predictable_delivery-v1.json",
       "concerned_about_debt-v1.json",
       "cto_celebrates_delivery-v1.json",
       "cto_frustrated_by_stagnation-v1.json",
+      "cto_impressed_by_architecture-v1.json",
+      "cto_questions_investment-v1.json",
       "cto_wants_clarity-v1.json",
+      "ipm_celebrates_integration_milestone-v1.json",
+      "ipm_demands_visible_progress-v1.json",
+      "ipm_escalates_integration_stall-v1.json",
+      "lead_dev_appreciates_team_investment-v1.json",
       "lead_dev_energized_by_clarity-v1.json",
       "lead_dev_fights_for_quality-v1.json",
+      "lead_dev_trusts_the_process-v1.json",
       "lead_developer_threatens_resignation-v1.json",
       "ops_manager_confident_in_stability-v1.json",
       "ops_manager_demands_incident_review-v1.json",
       "ops_manager_stressed_by_instability-v1.json",
+      "ops_manager_trusts_pipeline-v1.json",
       "security_officer_escalates_to_board-v1.json",
       "security_officer_flags_risky_system-v1.json",
+      "security_officer_relaxes_stance-v1.json",
       "security_officer_supports_clear_boundaries-v1.json",
       "tech_lead_appreciates_clean_code-v1.json",
+      "tech_lead_champions_architecture-v1.json",
       "vp_product_celebrates_user_growth-v1.json",
       "vp_product_demands_features-v1.json",
+      "vp_product_endorses_strategy-v1.json",
+      "vp_product_loses_patience-v1.json",
       "vp_product_worried_about_users-v1.json"
     ],
     "scores": [
@@ -136,32 +184,59 @@
       "version_mismatch-v1.json"
     ],
     "events": [
+      "acquisition_rumor-v1.json",
+      "architecture_award_nomination-v1.json",
+      "auditor_finds_clean_module-v1.json",
       "critical_bug_discovered-v1.json",
+      "cross_team_hackathon-v1.json",
+      "culture_clash_incident-v1.json",
       "customer_escalation-v1.json",
       "customer_praises_reliability-v1.json",
       "data_breach_reported-v1.json",
       "dependency_breaks_unexpectedly-v1.json",
+      "duplicate_system_discovery-v1.json",
+      "integration_demo_success-v1.json",
+      "investor_board_presentation-v1.json",
       "key_engineer_leaves-v1.json",
+      "key_talent_poaching_attempt-v1.json",
+      "legacy_system_wins_award-v1.json",
+      "new_cto_mandate-v1.json",
+      "open_source_contribution_viral-v1.json",
       "production_incident-v1.json",
       "regulatory_compliance_deadline-v1.json",
+      "service_discovery_failure-v1.json",
       "service_outage_cascade-v1.json",
+      "shadow_process_revealed-v1.json",
+      "successful_demo_day-v1.json",
       "surprise_budget_cut-v1.json",
+      "team_burnout_spike-v1.json",
       "team_member_discovers_pattern-v1.json",
-      "urgent_feature_request-v1.json"
+      "urgent_feature_request-v1.json",
+      "vendor_partnership_offer-v1.json"
     ],
     "delayed_effects": [
       "api_migration_friction-v1.json",
       "audit_findings_surface-v1.json",
       "boundaries_clarify-v1.json",
+      "burnout_recovery_stalls-v1.json",
+      "compliance_clarity_spreads-v1.json",
       "contractor_knowledge_leaves-v1.json",
+      "culture_alignment_progress-v1.json",
+      "demo_momentum-v1.json",
       "dependency_stability_improves-v1.json",
       "documentation_helps_onboarding-v1.json",
+      "duplicate_system_costs-v1.json",
       "improved_clarity-v1.json",
       "integration_complexity_emerges-v1.json",
+      "investor_confidence_boost-v1.json",
       "knowledge_gap_widens-v1.json",
+      "open_source_community_grows-v1.json",
+      "partnership_integration_costs-v1.json",
+      "platform_maturity-v1.json",
       "refactoring_payoff-v1.json",
       "team_energized-v1.json",
       "technical_debt_accumulates-v1.json",
+      "unified_model_clarity-v1.json",
       "user_trust_recovers-v1.json"
     ],
     "outcome_tiers": [
@@ -173,10 +248,15 @@
     ],
     "outcome_archetypes": [
       "boundary_builder-v1.json",
+      "budget_hawk-v1.json",
+      "burnout_machine-v1.json",
       "firefighter-v1.json",
       "runaway_refactorer-v1.json",
       "stakeholder_whisperer-v1.json",
-      "system_stabilizer-v1.json"
+      "system_stabilizer-v1.json",
+      "the_diplomat-v1.json",
+      "the_pragmatist-v1.json",
+      "the_visionary-v1.json"
     ],
     "classes": [
       "boundary_mage-v1.json",
@@ -184,6 +264,12 @@
       "legacy_ranger-v1.json",
       "reliability_cleric-v1.json",
       "stakeholder_bard-v1.json"
+    ],
+    "challenge_modifiers": [
+      "budget_crisis-v1.json",
+      "hard_mode-v1.json",
+      "speed_run-v1.json",
+      "stakeholder_revolt-v1.json"
     ]
   }
 }

--- a/content/outcome-archetypes/budget_hawk-v1.json
+++ b/content/outcome-archetypes/budget_hawk-v1.json
@@ -1,0 +1,7 @@
+{
+  "id": "budget_hawk",
+  "version": 1,
+  "name": "The Budget Hawk",
+  "description": "You proved that good architecture doesn't have to break the bank",
+  "flavor_text": "The CFO's new favorite architect"
+}

--- a/content/outcome-archetypes/burnout_machine-v1.json
+++ b/content/outcome-archetypes/burnout_machine-v1.json
@@ -1,0 +1,7 @@
+{
+  "id": "burnout_machine",
+  "version": 1,
+  "name": "The Burnout Machine",
+  "description": "You shipped everything on time, but at what cost? The team is exhausted",
+  "flavor_text": "Velocity was high. So was the turnover rate."
+}

--- a/content/outcome-archetypes/the_diplomat-v1.json
+++ b/content/outcome-archetypes/the_diplomat-v1.json
@@ -1,0 +1,7 @@
+{
+  "id": "the_diplomat",
+  "version": 1,
+  "name": "The Diplomat",
+  "description": "You kept every stakeholder at the table, even when the system was on fire",
+  "flavor_text": "Your greatest architecture decision was knowing who to talk to"
+}

--- a/content/outcome-archetypes/the_pragmatist-v1.json
+++ b/content/outcome-archetypes/the_pragmatist-v1.json
@@ -1,0 +1,7 @@
+{
+  "id": "the_pragmatist",
+  "version": 1,
+  "name": "The Pragmatist",
+  "description": "You balanced short-term fixes with long-term investments, never going to extremes",
+  "flavor_text": "Not glamorous, but everything still works"
+}

--- a/content/outcome-archetypes/the_visionary-v1.json
+++ b/content/outcome-archetypes/the_visionary-v1.json
@@ -1,0 +1,7 @@
+{
+  "id": "the_visionary",
+  "version": 1,
+  "name": "The Visionary",
+  "description": "You saw the big picture and reshaped the domain, even when others couldn't see why it mattered",
+  "flavor_text": "The architecture diagrams finally make sense"
+}

--- a/content/scenarios/compliance_gauntlet-v1.json
+++ b/content/scenarios/compliance_gauntlet-v1.json
@@ -10,8 +10,8 @@
   "starting_scores": {
     "domain_clarity": 50,
     "maintainability": 44,
-    "delivery_confidence": 45,
-    "team_morale": 40,
+    "delivery_confidence": 38,
+    "team_morale": 32,
     "user_trust": 55,
     "budget": 50
   },

--- a/content/scenarios/compliance_gauntlet-v1.json
+++ b/content/scenarios/compliance_gauntlet-v1.json
@@ -6,6 +6,7 @@
   "short_description": "Survive a regulatory gauntlet without losing delivery capability or stakeholder confidence.",
   "flavor_text": "The auditors are coming, and suddenly everyone cares how the system actually works",
   "max_turns": 12,
+  "score_variance": 5,
   "starting_scores": {
     "domain_clarity": 50,
     "maintainability": 44,
@@ -47,7 +48,10 @@
     { "id": "run_security_audit", "version": 1 },
     { "id": "pin_and_audit_dependencies", "version": 1 },
     { "id": "implement_feature_flag_framework", "version": 1 },
-    { "id": "automate_deployment_pipeline", "version": 1 }
+    { "id": "automate_deployment_pipeline", "version": 1 },
+    { "id": "accept_technical_debt_amnesty", "version": 1 },
+    { "id": "emergency_architecture_review", "version": 1 },
+    { "id": "cancel_feature_sprint_for_refactoring", "version": 1 }
   ],
   "event_refs": [
     { "id": "critical_bug_discovered", "version": 1 },
@@ -57,7 +61,12 @@
     { "id": "regulatory_compliance_deadline", "version": 1 },
     { "id": "key_engineer_leaves", "version": 1 },
     { "id": "customer_escalation", "version": 1 },
-    { "id": "data_breach_reported", "version": 1 }
+    { "id": "data_breach_reported", "version": 1 },
+    { "id": "auditor_finds_clean_module", "version": 1 },
+    { "id": "new_cto_mandate", "version": 1 },
+    { "id": "team_burnout_spike", "version": 1 },
+    { "id": "successful_demo_day", "version": 1 },
+    { "id": "vendor_partnership_offer", "version": 1 }
   ],
   "outcome_tier_refs": [
     { "id": "triumph", "version": 1 },
@@ -71,6 +80,11 @@
     { "id": "firefighter", "version": 1 },
     { "id": "system_stabilizer", "version": 1 },
     { "id": "stakeholder_whisperer", "version": 1 },
-    { "id": "runaway_refactorer", "version": 1 }
+    { "id": "runaway_refactorer", "version": 1 },
+    { "id": "the_diplomat", "version": 1 },
+    { "id": "budget_hawk", "version": 1 },
+    { "id": "the_pragmatist", "version": 1 },
+    { "id": "the_visionary", "version": 1 },
+    { "id": "burnout_machine", "version": 1 }
   ]
 }

--- a/content/scenarios/merger_of_minor_chaos-v1.json
+++ b/content/scenarios/merger_of_minor_chaos-v1.json
@@ -1,0 +1,90 @@
+{
+  "id": "merger_of_minor_chaos",
+  "version": 1,
+  "name": "The Merger of Minor Chaos",
+  "description": "Two mid-size companies have merged, and now you must reconcile duplicate systems, competing domain models, and culture clashes while proving 'synergy' is more than a buzzword",
+  "short_description": "Unite two engineering cultures and tech stacks before integration paralysis sets in.",
+  "flavor_text": "Two domain models enter. One domain model leaves. Hopefully.",
+  "max_turns": 11,
+  "score_variance": 5,
+  "starting_scores": {
+    "domain_clarity": 25,
+    "maintainability": 40,
+    "delivery_confidence": 50,
+    "team_morale": 45,
+    "user_trust": 55,
+    "budget": 70
+  },
+  "score_refs": [
+    { "id": "domain_clarity", "version": 1 },
+    { "id": "maintainability", "version": 1 },
+    { "id": "delivery_confidence", "version": 1 },
+    { "id": "team_morale", "version": 1 },
+    { "id": "user_trust", "version": 1 },
+    { "id": "budget", "version": 1 }
+  ],
+  "stakeholder_refs": [
+    { "id": "cto", "version": 1 },
+    { "id": "vp_product", "version": 1 },
+    { "id": "lead_developer", "version": 1 },
+    { "id": "operations_manager", "version": 1 },
+    { "id": "integration_program_manager", "version": 1 }
+  ],
+  "card_refs": [
+    { "id": "define_bounded_context", "version": 1 },
+    { "id": "extract_shared_kernel", "version": 1 },
+    { "id": "document_ubiquitous_language", "version": 1 },
+    { "id": "introduce_anti_corruption_layer", "version": 1 },
+    { "id": "ship_quick_fix", "version": 1 },
+    { "id": "hold_architecture_workshop", "version": 1 },
+    { "id": "add_integration_tests", "version": 1 },
+    { "id": "establish_team_ownership", "version": 1 },
+    { "id": "introduce_event_storming", "version": 1 },
+    { "id": "clarify_cross_team_handoffs", "version": 1 },
+    { "id": "host_cross_team_retrospective", "version": 1 },
+    { "id": "negotiate_technical_runway", "version": 1 },
+    { "id": "absorb_emergency_production_fix", "version": 1 },
+    { "id": "automate_deployment_pipeline", "version": 1 },
+    { "id": "propose_unified_domain_model", "version": 1 },
+    { "id": "run_integration_workshop", "version": 1 },
+    { "id": "sunset_duplicate_system", "version": 1 },
+    { "id": "shadow_it_consolidation", "version": 1 },
+    { "id": "platform_team_formation", "version": 1 },
+    { "id": "emergency_architecture_review", "version": 1 },
+    { "id": "publish_engineering_blog", "version": 1 }
+  ],
+  "event_refs": [
+    { "id": "critical_bug_discovered", "version": 1 },
+    { "id": "customer_praises_reliability", "version": 1 },
+    { "id": "team_member_discovers_pattern", "version": 1 },
+    { "id": "key_engineer_leaves", "version": 1 },
+    { "id": "customer_escalation", "version": 1 },
+    { "id": "key_talent_poaching_attempt", "version": 1 },
+    { "id": "duplicate_system_discovery", "version": 1 },
+    { "id": "culture_clash_incident", "version": 1 },
+    { "id": "integration_demo_success", "version": 1 },
+    { "id": "shadow_process_revealed", "version": 1 },
+    { "id": "acquisition_rumor", "version": 1 },
+    { "id": "cross_team_hackathon", "version": 1 },
+    { "id": "team_burnout_spike", "version": 1 }
+  ],
+  "outcome_tier_refs": [
+    { "id": "triumph", "version": 1 },
+    { "id": "success", "version": 1 },
+    { "id": "survival", "version": 1 },
+    { "id": "struggle", "version": 1 },
+    { "id": "collapse", "version": 1 }
+  ],
+  "outcome_archetype_refs": [
+    { "id": "boundary_builder", "version": 1 },
+    { "id": "firefighter", "version": 1 },
+    { "id": "system_stabilizer", "version": 1 },
+    { "id": "stakeholder_whisperer", "version": 1 },
+    { "id": "runaway_refactorer", "version": 1 },
+    { "id": "the_diplomat", "version": 1 },
+    { "id": "the_pragmatist", "version": 1 },
+    { "id": "the_visionary", "version": 1 },
+    { "id": "burnout_machine", "version": 1 },
+    { "id": "budget_hawk", "version": 1 }
+  ]
+}

--- a/content/scenarios/merger_of_minor_chaos-v1.json
+++ b/content/scenarios/merger_of_minor_chaos-v1.json
@@ -9,11 +9,11 @@
   "score_variance": 5,
   "starting_scores": {
     "domain_clarity": 25,
-    "maintainability": 40,
-    "delivery_confidence": 50,
-    "team_morale": 45,
+    "maintainability": 35,
+    "delivery_confidence": 45,
+    "team_morale": 40,
     "user_trust": 55,
-    "budget": 70
+    "budget": 65
   },
   "score_refs": [
     { "id": "domain_clarity", "version": 1 },
@@ -66,7 +66,10 @@
     { "id": "shadow_process_revealed", "version": 1 },
     { "id": "acquisition_rumor", "version": 1 },
     { "id": "cross_team_hackathon", "version": 1 },
-    { "id": "team_burnout_spike", "version": 1 }
+    { "id": "team_burnout_spike", "version": 1 },
+    { "id": "successful_demo_day", "version": 1 },
+    { "id": "vendor_partnership_offer", "version": 1 },
+    { "id": "open_source_contribution_viral", "version": 1 }
   ],
   "outcome_tier_refs": [
     { "id": "triumph", "version": 1 },

--- a/content/scenarios/microservice_sprawl-v1.json
+++ b/content/scenarios/microservice_sprawl-v1.json
@@ -6,6 +6,7 @@
   "short_description": "Restore clarity to a fragmented service landscape before coordination failure becomes the norm.",
   "flavor_text": "Every service has a boundary. Very few of them make sense",
   "max_turns": 9,
+  "score_variance": 5,
   "starting_scores": {
     "domain_clarity": 25,
     "maintainability": 40,
@@ -47,7 +48,12 @@
     { "id": "pin_and_audit_dependencies", "version": 1 },
     { "id": "host_cross_team_retrospective", "version": 1 },
     { "id": "deprecate_legacy_api", "version": 1 },
-    { "id": "automate_deployment_pipeline", "version": 1 }
+    { "id": "automate_deployment_pipeline", "version": 1 },
+    { "id": "propose_microservice_extraction", "version": 1 },
+    { "id": "shadow_it_consolidation", "version": 1 },
+    { "id": "platform_team_formation", "version": 1 },
+    { "id": "emergency_architecture_review", "version": 1 },
+    { "id": "publish_engineering_blog", "version": 1 }
   ],
   "event_refs": [
     { "id": "critical_bug_discovered", "version": 1 },
@@ -56,7 +62,12 @@
     { "id": "team_member_discovers_pattern", "version": 1 },
     { "id": "service_outage_cascade", "version": 1 },
     { "id": "key_engineer_leaves", "version": 1 },
-    { "id": "customer_escalation", "version": 1 }
+    { "id": "customer_escalation", "version": 1 },
+    { "id": "service_discovery_failure", "version": 1 },
+    { "id": "cross_team_hackathon", "version": 1 },
+    { "id": "team_burnout_spike", "version": 1 },
+    { "id": "architecture_award_nomination", "version": 1 },
+    { "id": "successful_demo_day", "version": 1 }
   ],
   "outcome_tier_refs": [
     { "id": "triumph", "version": 1 },
@@ -70,6 +81,11 @@
     { "id": "firefighter", "version": 1 },
     { "id": "system_stabilizer", "version": 1 },
     { "id": "stakeholder_whisperer", "version": 1 },
-    { "id": "runaway_refactorer", "version": 1 }
+    { "id": "runaway_refactorer", "version": 1 },
+    { "id": "the_diplomat", "version": 1 },
+    { "id": "budget_hawk", "version": 1 },
+    { "id": "the_pragmatist", "version": 1 },
+    { "id": "the_visionary", "version": 1 },
+    { "id": "burnout_machine", "version": 1 }
   ]
 }

--- a/content/scenarios/monolith_of_mild_despair-v1.json
+++ b/content/scenarios/monolith_of_mild_despair-v1.json
@@ -6,6 +6,7 @@
   "short_description": "Stabilize a tangled legacy monolith before delivery confidence collapses.",
   "flavor_text": "You inherit a codebase where every change touches everything",
   "max_turns": 10,
+  "score_variance": 5,
   "starting_scores": {
     "domain_clarity": 30,
     "maintainability": 38,
@@ -142,6 +143,26 @@
     {
       "id": "align_budget_with_architecture",
       "version": 1
+    },
+    {
+      "id": "propose_microservice_extraction",
+      "version": 1
+    },
+    {
+      "id": "accept_technical_debt_amnesty",
+      "version": 1
+    },
+    {
+      "id": "sunset_legacy_feature",
+      "version": 1
+    },
+    {
+      "id": "emergency_architecture_review",
+      "version": 1
+    },
+    {
+      "id": "cancel_feature_sprint_for_refactoring",
+      "version": 1
     }
   ],
   "event_refs": [
@@ -167,6 +188,26 @@
     },
     {
       "id": "customer_escalation",
+      "version": 1
+    },
+    {
+      "id": "legacy_system_wins_award",
+      "version": 1
+    },
+    {
+      "id": "team_burnout_spike",
+      "version": 1
+    },
+    {
+      "id": "vendor_partnership_offer",
+      "version": 1
+    },
+    {
+      "id": "architecture_award_nomination",
+      "version": 1
+    },
+    {
+      "id": "new_cto_mandate",
       "version": 1
     }
   ],
@@ -211,6 +252,26 @@
     },
     {
       "id": "runaway_refactorer",
+      "version": 1
+    },
+    {
+      "id": "the_diplomat",
+      "version": 1
+    },
+    {
+      "id": "budget_hawk",
+      "version": 1
+    },
+    {
+      "id": "the_pragmatist",
+      "version": 1
+    },
+    {
+      "id": "the_visionary",
+      "version": 1
+    },
+    {
+      "id": "burnout_machine",
       "version": 1
     }
   ]

--- a/content/scenarios/monolith_of_mild_despair-v1.json
+++ b/content/scenarios/monolith_of_mild_despair-v1.json
@@ -11,9 +11,9 @@
     "domain_clarity": 30,
     "maintainability": 38,
     "delivery_confidence": 50,
-    "team_morale": 50,
+    "team_morale": 42,
     "user_trust": 55,
-    "budget": 65
+    "budget": 58
   },
   "score_refs": [
     {

--- a/content/scenarios/startup_hypergrowth-v1.json
+++ b/content/scenarios/startup_hypergrowth-v1.json
@@ -9,11 +9,11 @@
   "score_variance": 5,
   "starting_scores": {
     "domain_clarity": 35,
-    "maintainability": 45,
+    "maintainability": 40,
     "delivery_confidence": 55,
-    "team_morale": 50,
+    "team_morale": 45,
     "user_trust": 50,
-    "budget": 58
+    "budget": 53
   },
   "score_refs": [
     { "id": "domain_clarity", "version": 1 },
@@ -71,7 +71,9 @@
     { "id": "open_source_contribution_viral", "version": 1 },
     { "id": "acquisition_rumor", "version": 1 },
     { "id": "successful_demo_day", "version": 1 },
-    { "id": "team_burnout_spike", "version": 1 }
+    { "id": "team_burnout_spike", "version": 1 },
+    { "id": "vendor_partnership_offer", "version": 1 },
+    { "id": "cross_team_hackathon", "version": 1 }
   ],
   "outcome_tier_refs": [
     { "id": "triumph", "version": 1 },

--- a/content/scenarios/startup_hypergrowth-v1.json
+++ b/content/scenarios/startup_hypergrowth-v1.json
@@ -11,9 +11,9 @@
     "domain_clarity": 35,
     "maintainability": 45,
     "delivery_confidence": 55,
-    "team_morale": 65,
+    "team_morale": 50,
     "user_trust": 50,
-    "budget": 75
+    "budget": 58
   },
   "score_refs": [
     { "id": "domain_clarity", "version": 1 },

--- a/content/scenarios/startup_hypergrowth-v1.json
+++ b/content/scenarios/startup_hypergrowth-v1.json
@@ -6,6 +6,7 @@
   "short_description": "Scale a fast-growing product before delivery chaos and user pain spiral out of control.",
   "flavor_text": "Traffic is soaring, expectations are higher, and the architecture is starting to sweat",
   "max_turns": 10,
+  "score_variance": 5,
   "starting_scores": {
     "domain_clarity": 35,
     "maintainability": 45,
@@ -48,7 +49,12 @@
     { "id": "absorb_emergency_production_fix", "version": 1 },
     { "id": "implement_feature_flag_framework", "version": 1 },
     { "id": "hire_specialized_contractor", "version": 1 },
-    { "id": "automate_deployment_pipeline", "version": 1 }
+    { "id": "automate_deployment_pipeline", "version": 1 },
+    { "id": "platform_team_formation", "version": 1 },
+    { "id": "accept_technical_debt_amnesty", "version": 1 },
+    { "id": "propose_microservice_extraction", "version": 1 },
+    { "id": "publish_engineering_blog", "version": 1 },
+    { "id": "sunset_legacy_feature", "version": 1 }
   ],
   "event_refs": [
     { "id": "critical_bug_discovered", "version": 1 },
@@ -59,7 +65,13 @@
     { "id": "surprise_budget_cut", "version": 1 },
     { "id": "key_engineer_leaves", "version": 1 },
     { "id": "customer_escalation", "version": 1 },
-    { "id": "data_breach_reported", "version": 1 }
+    { "id": "data_breach_reported", "version": 1 },
+    { "id": "investor_board_presentation", "version": 1 },
+    { "id": "key_talent_poaching_attempt", "version": 1 },
+    { "id": "open_source_contribution_viral", "version": 1 },
+    { "id": "acquisition_rumor", "version": 1 },
+    { "id": "successful_demo_day", "version": 1 },
+    { "id": "team_burnout_spike", "version": 1 }
   ],
   "outcome_tier_refs": [
     { "id": "triumph", "version": 1 },
@@ -73,6 +85,11 @@
     { "id": "firefighter", "version": 1 },
     { "id": "system_stabilizer", "version": 1 },
     { "id": "stakeholder_whisperer", "version": 1 },
-    { "id": "runaway_refactorer", "version": 1 }
+    { "id": "runaway_refactorer", "version": 1 },
+    { "id": "the_diplomat", "version": 1 },
+    { "id": "budget_hawk", "version": 1 },
+    { "id": "the_pragmatist", "version": 1 },
+    { "id": "the_visionary", "version": 1 },
+    { "id": "burnout_machine", "version": 1 }
   ]
 }

--- a/content/stakeholder-reaction-rules/cfo_appreciates_cost_efficiency-v1.json
+++ b/content/stakeholder-reaction-rules/cfo_appreciates_cost_efficiency-v1.json
@@ -3,15 +3,15 @@
   "version": 1,
   "name": "CFO Appreciates Cost Efficiency",
   "description": "The CFO recognizes that improved maintainability reduces costly production incidents",
-  "condition_description": "Maintainability > 55",
+  "condition_description": "Maintainability > 70",
   "score_changes": [
     {
       "score_id": "budget",
-      "delta": 4
+      "delta": 2
     },
     {
       "score_id": "delivery_confidence",
-      "delta": 2
+      "delta": 1
     }
   ],
   "stakeholder_changes": [

--- a/content/stakeholder-reaction-rules/cfo_appreciates_cost_efficiency-v1.json
+++ b/content/stakeholder-reaction-rules/cfo_appreciates_cost_efficiency-v1.json
@@ -1,0 +1,23 @@
+{
+  "id": "cfo_appreciates_cost_efficiency",
+  "version": 1,
+  "name": "CFO Appreciates Cost Efficiency",
+  "description": "The CFO recognizes that improved maintainability reduces costly production incidents",
+  "condition_description": "Maintainability > 55",
+  "score_changes": [
+    {
+      "score_id": "budget",
+      "delta": 4
+    },
+    {
+      "score_id": "delivery_confidence",
+      "delta": 2
+    }
+  ],
+  "stakeholder_changes": [
+    {
+      "stakeholder_id": "cfo",
+      "delta": 5
+    }
+  ]
+}

--- a/content/stakeholder-reaction-rules/cto_impressed_by_architecture-v1.json
+++ b/content/stakeholder-reaction-rules/cto_impressed_by_architecture-v1.json
@@ -1,0 +1,23 @@
+{
+  "id": "cto_impressed_by_architecture",
+  "version": 1,
+  "name": "CTO Impressed by Architecture",
+  "description": "The CTO is energized by clear architectural progress and increased system quality",
+  "condition_description": "Domain clarity > 55",
+  "score_changes": [
+    {
+      "score_id": "team_morale",
+      "delta": 3
+    },
+    {
+      "score_id": "budget",
+      "delta": 3
+    }
+  ],
+  "stakeholder_changes": [
+    {
+      "stakeholder_id": "cto",
+      "delta": 6
+    }
+  ]
+}

--- a/content/stakeholder-reaction-rules/cto_impressed_by_architecture-v1.json
+++ b/content/stakeholder-reaction-rules/cto_impressed_by_architecture-v1.json
@@ -3,15 +3,15 @@
   "version": 1,
   "name": "CTO Impressed by Architecture",
   "description": "The CTO is energized by clear architectural progress and increased system quality",
-  "condition_description": "Domain clarity > 55",
+  "condition_description": "Domain clarity > 70",
   "score_changes": [
     {
       "score_id": "team_morale",
-      "delta": 3
+      "delta": 1
     },
     {
       "score_id": "budget",
-      "delta": 3
+      "delta": 2
     }
   ],
   "stakeholder_changes": [

--- a/content/stakeholder-reaction-rules/cto_questions_investment-v1.json
+++ b/content/stakeholder-reaction-rules/cto_questions_investment-v1.json
@@ -1,0 +1,24 @@
+{
+  "id": "cto_questions_investment",
+  "version": 1,
+  "name": "CTO Questions Investment",
+  "description": "The CTO questions whether architecture investments are paying off when budget is tight and clarity hasn't improved",
+  "condition_description": "Budget < 30",
+  "priority": 40,
+  "score_changes": [
+    {
+      "score_id": "team_morale",
+      "delta": -3
+    },
+    {
+      "score_id": "domain_clarity",
+      "delta": -2
+    }
+  ],
+  "stakeholder_changes": [
+    {
+      "stakeholder_id": "cto",
+      "delta": -6
+    }
+  ]
+}

--- a/content/stakeholder-reaction-rules/ipm_celebrates_integration_milestone-v1.json
+++ b/content/stakeholder-reaction-rules/ipm_celebrates_integration_milestone-v1.json
@@ -1,0 +1,23 @@
+{
+  "id": "ipm_celebrates_integration_milestone",
+  "version": 1,
+  "name": "IPM Celebrates Integration Milestone",
+  "description": "The integration program manager is pleased when domain clarity shows real integration progress",
+  "condition_description": "Domain clarity > 55",
+  "score_changes": [
+    {
+      "score_id": "budget",
+      "delta": 4
+    },
+    {
+      "score_id": "team_morale",
+      "delta": 3
+    }
+  ],
+  "stakeholder_changes": [
+    {
+      "stakeholder_id": "integration_program_manager",
+      "delta": 6
+    }
+  ]
+}

--- a/content/stakeholder-reaction-rules/ipm_demands_visible_progress-v1.json
+++ b/content/stakeholder-reaction-rules/ipm_demands_visible_progress-v1.json
@@ -1,0 +1,23 @@
+{
+  "id": "ipm_demands_visible_progress",
+  "version": 1,
+  "name": "IPM Demands Visible Progress",
+  "description": "The integration program manager needs visible architectural progress for steering committee reports",
+  "condition_description": "Domain clarity < 35",
+  "score_changes": [
+    {
+      "score_id": "team_morale",
+      "delta": -3
+    },
+    {
+      "score_id": "budget",
+      "delta": -2
+    }
+  ],
+  "stakeholder_changes": [
+    {
+      "stakeholder_id": "integration_program_manager",
+      "delta": -5
+    }
+  ]
+}

--- a/content/stakeholder-reaction-rules/ipm_escalates_integration_stall-v1.json
+++ b/content/stakeholder-reaction-rules/ipm_escalates_integration_stall-v1.json
@@ -1,0 +1,28 @@
+{
+  "id": "ipm_escalates_integration_stall",
+  "version": 1,
+  "name": "IPM Escalates Integration Stall",
+  "description": "The integration program manager escalates when the merger integration fundamentally stalls",
+  "condition_description": "Domain clarity < 20",
+  "priority": 50,
+  "score_changes": [
+    {
+      "score_id": "delivery_confidence",
+      "delta": -4
+    },
+    {
+      "score_id": "budget",
+      "delta": -4
+    },
+    {
+      "score_id": "team_morale",
+      "delta": -3
+    }
+  ],
+  "stakeholder_changes": [
+    {
+      "stakeholder_id": "integration_program_manager",
+      "delta": -8
+    }
+  ]
+}

--- a/content/stakeholder-reaction-rules/lead_dev_appreciates_team_investment-v1.json
+++ b/content/stakeholder-reaction-rules/lead_dev_appreciates_team_investment-v1.json
@@ -1,0 +1,23 @@
+{
+  "id": "lead_dev_appreciates_team_investment",
+  "version": 1,
+  "name": "Lead Dev Appreciates Team Investment",
+  "description": "The lead developer is grateful when investment in quality starts paying off",
+  "condition_description": "Maintainability > 60",
+  "score_changes": [
+    {
+      "score_id": "team_morale",
+      "delta": 4
+    },
+    {
+      "score_id": "delivery_confidence",
+      "delta": 2
+    }
+  ],
+  "stakeholder_changes": [
+    {
+      "stakeholder_id": "lead_developer",
+      "delta": 6
+    }
+  ]
+}

--- a/content/stakeholder-reaction-rules/lead_dev_appreciates_team_investment-v1.json
+++ b/content/stakeholder-reaction-rules/lead_dev_appreciates_team_investment-v1.json
@@ -3,14 +3,10 @@
   "version": 1,
   "name": "Lead Dev Appreciates Team Investment",
   "description": "The lead developer is grateful when investment in quality starts paying off",
-  "condition_description": "Maintainability > 60",
+  "condition_description": "Maintainability > 75",
   "score_changes": [
     {
       "score_id": "team_morale",
-      "delta": 4
-    },
-    {
-      "score_id": "delivery_confidence",
       "delta": 2
     }
   ],

--- a/content/stakeholder-reaction-rules/lead_dev_trusts_the_process-v1.json
+++ b/content/stakeholder-reaction-rules/lead_dev_trusts_the_process-v1.json
@@ -3,14 +3,10 @@
   "version": 1,
   "name": "Lead Developer Trusts the Process",
   "description": "The lead developer rallies the team when morale is strong and the direction feels right",
-  "condition_description": "Team morale > 65",
+  "condition_description": "Team morale > 80",
   "score_changes": [
     {
       "score_id": "maintainability",
-      "delta": 3
-    },
-    {
-      "score_id": "delivery_confidence",
       "delta": 2
     }
   ],

--- a/content/stakeholder-reaction-rules/lead_dev_trusts_the_process-v1.json
+++ b/content/stakeholder-reaction-rules/lead_dev_trusts_the_process-v1.json
@@ -1,0 +1,23 @@
+{
+  "id": "lead_dev_trusts_the_process",
+  "version": 1,
+  "name": "Lead Developer Trusts the Process",
+  "description": "The lead developer rallies the team when morale is strong and the direction feels right",
+  "condition_description": "Team morale > 65",
+  "score_changes": [
+    {
+      "score_id": "maintainability",
+      "delta": 3
+    },
+    {
+      "score_id": "delivery_confidence",
+      "delta": 2
+    }
+  ],
+  "stakeholder_changes": [
+    {
+      "stakeholder_id": "lead_developer",
+      "delta": 5
+    }
+  ]
+}

--- a/content/stakeholder-reaction-rules/ops_manager_trusts_pipeline-v1.json
+++ b/content/stakeholder-reaction-rules/ops_manager_trusts_pipeline-v1.json
@@ -1,0 +1,23 @@
+{
+  "id": "ops_manager_trusts_pipeline",
+  "version": 1,
+  "name": "Ops Manager Trusts the Pipeline",
+  "description": "The operations manager gains confidence when delivery processes are predictable",
+  "condition_description": "Delivery confidence > 60",
+  "score_changes": [
+    {
+      "score_id": "user_trust",
+      "delta": 3
+    },
+    {
+      "score_id": "team_morale",
+      "delta": 2
+    }
+  ],
+  "stakeholder_changes": [
+    {
+      "stakeholder_id": "operations_manager",
+      "delta": 5
+    }
+  ]
+}

--- a/content/stakeholder-reaction-rules/ops_manager_trusts_pipeline-v1.json
+++ b/content/stakeholder-reaction-rules/ops_manager_trusts_pipeline-v1.json
@@ -3,14 +3,10 @@
   "version": 1,
   "name": "Ops Manager Trusts the Pipeline",
   "description": "The operations manager gains confidence when delivery processes are predictable",
-  "condition_description": "Delivery confidence > 60",
+  "condition_description": "Delivery confidence > 75",
   "score_changes": [
     {
       "score_id": "user_trust",
-      "delta": 3
-    },
-    {
-      "score_id": "team_morale",
       "delta": 2
     }
   ],

--- a/content/stakeholder-reaction-rules/security_officer_relaxes_stance-v1.json
+++ b/content/stakeholder-reaction-rules/security_officer_relaxes_stance-v1.json
@@ -1,0 +1,23 @@
+{
+  "id": "security_officer_relaxes_stance",
+  "version": 1,
+  "name": "Security Officer Relaxes Stance",
+  "description": "The security officer is reassured when user trust is solid and the system is well-maintained",
+  "condition_description": "User trust > 65",
+  "score_changes": [
+    {
+      "score_id": "delivery_confidence",
+      "delta": 2
+    },
+    {
+      "score_id": "team_morale",
+      "delta": 2
+    }
+  ],
+  "stakeholder_changes": [
+    {
+      "stakeholder_id": "security_officer",
+      "delta": 5
+    }
+  ]
+}

--- a/content/stakeholder-reaction-rules/security_officer_relaxes_stance-v1.json
+++ b/content/stakeholder-reaction-rules/security_officer_relaxes_stance-v1.json
@@ -3,15 +3,15 @@
   "version": 1,
   "name": "Security Officer Relaxes Stance",
   "description": "The security officer is reassured when user trust is solid and the system is well-maintained",
-  "condition_description": "User trust > 65",
+  "condition_description": "User trust > 80",
   "score_changes": [
     {
       "score_id": "delivery_confidence",
-      "delta": 2
+      "delta": 1
     },
     {
       "score_id": "team_morale",
-      "delta": 2
+      "delta": 1
     }
   ],
   "stakeholder_changes": [

--- a/content/stakeholder-reaction-rules/tech_lead_champions_architecture-v1.json
+++ b/content/stakeholder-reaction-rules/tech_lead_champions_architecture-v1.json
@@ -1,0 +1,23 @@
+{
+  "id": "tech_lead_champions_architecture",
+  "version": 1,
+  "name": "Tech Lead Champions Architecture",
+  "description": "The tech lead actively promotes architectural improvements when domain clarity is solid",
+  "condition_description": "Domain clarity > 55",
+  "score_changes": [
+    {
+      "score_id": "maintainability",
+      "delta": 3
+    },
+    {
+      "score_id": "team_morale",
+      "delta": 2
+    }
+  ],
+  "stakeholder_changes": [
+    {
+      "stakeholder_id": "tech_lead",
+      "delta": 5
+    }
+  ]
+}

--- a/content/stakeholder-reaction-rules/tech_lead_champions_architecture-v1.json
+++ b/content/stakeholder-reaction-rules/tech_lead_champions_architecture-v1.json
@@ -3,15 +3,15 @@
   "version": 1,
   "name": "Tech Lead Champions Architecture",
   "description": "The tech lead actively promotes architectural improvements when domain clarity is solid",
-  "condition_description": "Domain clarity > 55",
+  "condition_description": "Domain clarity > 70",
   "score_changes": [
     {
       "score_id": "maintainability",
-      "delta": 3
+      "delta": 2
     },
     {
       "score_id": "team_morale",
-      "delta": 2
+      "delta": 1
     }
   ],
   "stakeholder_changes": [

--- a/content/stakeholder-reaction-rules/vp_product_endorses_strategy-v1.json
+++ b/content/stakeholder-reaction-rules/vp_product_endorses_strategy-v1.json
@@ -1,0 +1,23 @@
+{
+  "id": "vp_product_endorses_strategy",
+  "version": 1,
+  "name": "VP Product Endorses Strategy",
+  "description": "The VP Product supports the current direction when both delivery and user trust are healthy",
+  "condition_description": "Delivery confidence > 55",
+  "score_changes": [
+    {
+      "score_id": "budget",
+      "delta": 3
+    },
+    {
+      "score_id": "team_morale",
+      "delta": 2
+    }
+  ],
+  "stakeholder_changes": [
+    {
+      "stakeholder_id": "vp_product",
+      "delta": 5
+    }
+  ]
+}

--- a/content/stakeholder-reaction-rules/vp_product_endorses_strategy-v1.json
+++ b/content/stakeholder-reaction-rules/vp_product_endorses_strategy-v1.json
@@ -3,14 +3,10 @@
   "version": 1,
   "name": "VP Product Endorses Strategy",
   "description": "The VP Product supports the current direction when both delivery and user trust are healthy",
-  "condition_description": "Delivery confidence > 55",
+  "condition_description": "Delivery confidence > 70",
   "score_changes": [
     {
       "score_id": "budget",
-      "delta": 3
-    },
-    {
-      "score_id": "team_morale",
       "delta": 2
     }
   ],

--- a/content/stakeholder-reaction-rules/vp_product_loses_patience-v1.json
+++ b/content/stakeholder-reaction-rules/vp_product_loses_patience-v1.json
@@ -1,0 +1,24 @@
+{
+  "id": "vp_product_loses_patience",
+  "version": 1,
+  "name": "VP Product Loses Patience",
+  "description": "The VP Product escalates to the CEO when both delivery and user trust are critically low",
+  "condition_description": "Delivery confidence < 25",
+  "priority": 50,
+  "score_changes": [
+    {
+      "score_id": "team_morale",
+      "delta": -4
+    },
+    {
+      "score_id": "budget",
+      "delta": -3
+    }
+  ],
+  "stakeholder_changes": [
+    {
+      "stakeholder_id": "vp_product",
+      "delta": -8
+    }
+  ]
+}

--- a/content/stakeholders/cfo-v1.json
+++ b/content/stakeholders/cfo-v1.json
@@ -15,6 +15,10 @@
     {
       "id": "cfo_alarmed_by_overspending",
       "version": 1
+    },
+    {
+      "id": "cfo_appreciates_cost_efficiency",
+      "version": 1
     }
   ]
 }

--- a/content/stakeholders/cto-v1.json
+++ b/content/stakeholders/cto-v1.json
@@ -15,6 +15,14 @@
     {
       "id": "cto_frustrated_by_stagnation",
       "version": 1
+    },
+    {
+      "id": "cto_impressed_by_architecture",
+      "version": 1
+    },
+    {
+      "id": "cto_questions_investment",
+      "version": 1
     }
   ]
 }

--- a/content/stakeholders/integration_program_manager-v1.json
+++ b/content/stakeholders/integration_program_manager-v1.json
@@ -1,0 +1,20 @@
+{
+  "id": "integration_program_manager",
+  "version": 1,
+  "name": "Integration Program Manager",
+  "description": "Cross-company coordinator focused on visible integration milestones and synergy metrics",
+  "reaction_rule_refs": [
+    {
+      "id": "ipm_demands_visible_progress",
+      "version": 1
+    },
+    {
+      "id": "ipm_celebrates_integration_milestone",
+      "version": 1
+    },
+    {
+      "id": "ipm_escalates_integration_stall",
+      "version": 1
+    }
+  ]
+}

--- a/content/stakeholders/lead_developer-v1.json
+++ b/content/stakeholders/lead_developer-v1.json
@@ -15,6 +15,14 @@
     {
       "id": "lead_developer_threatens_resignation",
       "version": 1
+    },
+    {
+      "id": "lead_dev_trusts_the_process",
+      "version": 1
+    },
+    {
+      "id": "lead_dev_appreciates_team_investment",
+      "version": 1
     }
   ]
 }

--- a/content/stakeholders/operations_manager-v1.json
+++ b/content/stakeholders/operations_manager-v1.json
@@ -15,6 +15,10 @@
     {
       "id": "ops_manager_demands_incident_review",
       "version": 1
+    },
+    {
+      "id": "ops_manager_trusts_pipeline",
+      "version": 1
     }
   ]
 }

--- a/content/stakeholders/security_officer-v1.json
+++ b/content/stakeholders/security_officer-v1.json
@@ -15,6 +15,10 @@
     {
       "id": "security_officer_escalates_to_board",
       "version": 1
+    },
+    {
+      "id": "security_officer_relaxes_stance",
+      "version": 1
     }
   ]
 }

--- a/content/stakeholders/tech_lead-v1.json
+++ b/content/stakeholders/tech_lead-v1.json
@@ -11,6 +11,10 @@
     {
       "id": "tech_lead_appreciates_clean_code",
       "version": 1
+    },
+    {
+      "id": "tech_lead_champions_architecture",
+      "version": 1
     }
   ]
 }

--- a/content/stakeholders/vp_product-v1.json
+++ b/content/stakeholders/vp_product-v1.json
@@ -15,6 +15,14 @@
     {
       "id": "vp_product_celebrates_user_growth",
       "version": 1
+    },
+    {
+      "id": "vp_product_endorses_strategy",
+      "version": 1
+    },
+    {
+      "id": "vp_product_loses_patience",
+      "version": 1
     }
   ]
 }

--- a/content/tutorial/manifest.json
+++ b/content/tutorial/manifest.json
@@ -20,6 +20,7 @@
   "pack_homepage_url": "https://github.com/mooeypoo/DDDnD",
   "scenarios": [],
   "classes": [],
+  "challenge_modifiers": [],
   "tutorials": [
     {
       "id": "tutorial_basics",
@@ -76,6 +77,7 @@
     "outcome_archetypes": [
       "tutorial_learner-v1.json"
     ],
-    "classes": []
+    "classes": [],
+    "challenge_modifiers": []
   }
 }

--- a/src/domains/content/model/content_pack_manifest.ts
+++ b/src/domains/content/model/content_pack_manifest.ts
@@ -21,6 +21,7 @@ export interface ContentPackInventory {
   outcome_tiers: string[]
   outcome_archetypes: string[]
   classes: string[]
+  challenge_modifiers: string[]
 }
 
 export interface ContentPackManifest {
@@ -35,6 +36,7 @@ export interface ContentPackManifest {
   pack_homepage_url?: string
   scenarios: VersionRef[]
   classes: VersionRef[]
+  challenge_modifiers: VersionRef[]
   tutorials: VersionRef[]
   tutorial_base_url?: string
   content: ContentPackInventory

--- a/src/domains/content/model/content_types.ts
+++ b/src/domains/content/model/content_types.ts
@@ -173,6 +173,8 @@ export interface Scenario extends ContentMetadata {
   outcome_tier_refs?: VersionRef[]
   outcome_archetype_refs?: VersionRef[]
   failure_conditions?: NumericCondition[]
+  /** Max ± random variance applied to each starting score per run */
+  score_variance?: number
   /** Tutorial-only: marks this scenario as a tutorial quest */
   is_tutorial?: boolean
   /** Tutorial-only: ordering among tutorials (1 = basics, 2 = advanced, etc.) */
@@ -184,10 +186,25 @@ export interface Scenario extends ContentMetadata {
 /**
  * Player Class
  * 
- * Cosmetic player class selection.
+ * Player class selection with optional gameplay bonus.
  */
 export interface PlayerClass extends ContentMetadata {
   name: string
   description: string
   flavor_text?: string
+  score_affinity?: string
+}
+
+/**
+ * Challenge Modifier
+ * 
+ * Optional difficulty modifier applied at run creation.
+ */
+export interface ChallengeModifier extends ContentMetadata {
+  name: string
+  description: string
+  flavor_text?: string
+  score_adjustments?: Record<string, number>
+  stakeholder_satisfaction_override?: number
+  turn_adjustment?: number
 }

--- a/src/domains/content/services/content_pack_registry.ts
+++ b/src/domains/content/services/content_pack_registry.ts
@@ -20,6 +20,7 @@ const contentKeyByType: Record<ContentType, ContentInventoryKey> = {
   'outcome-tiers': 'outcome_tiers',
   'outcome-archetypes': 'outcome_archetypes',
   classes: 'classes',
+  'challenge-modifiers': 'challenge_modifiers',
 }
 
 function dedupeVersionRefs(refs: VersionRef[]): VersionRef[] {
@@ -65,6 +66,10 @@ export class ContentPackRegistry {
 
   getAvailableClasses(): VersionRef[] {
     return dedupeVersionRefs(this.packs.flatMap((pack) => pack.manifest.classes))
+  }
+
+  getAvailableChallengeModifiers(): VersionRef[] {
+    return dedupeVersionRefs(this.packs.flatMap((pack) => pack.manifest.challenge_modifiers ?? []))
   }
 
   getAvailableTutorials(): VersionRef[] {
@@ -117,6 +122,7 @@ export class ContentPackRegistry {
       loadOutcomeArchetype: (ref) =>
         loadFromType('outcome-archetypes', ref, (provider, currentRef) => provider.loadOutcomeArchetype(currentRef)),
       loadPlayerClass: (ref) => loadFromType('classes', ref, (provider, currentRef) => provider.loadPlayerClass(currentRef)),
+      loadChallengeModifier: (ref) => loadFromType('challenge-modifiers', ref, (provider, currentRef) => provider.loadChallengeModifier(currentRef)),
     }
   }
 }

--- a/src/domains/content/services/content_provider.ts
+++ b/src/domains/content/services/content_provider.ts
@@ -23,6 +23,7 @@ import {
   OutcomeTier,
   OutcomeArchetype,
   PlayerClass,
+  ChallengeModifier,
   ContentMetadata,
   VersionRef,
   versionRefKey,
@@ -43,6 +44,7 @@ export type ContentType =
   | 'outcome-tiers'
   | 'outcome-archetypes'
   | 'classes'
+  | 'challenge-modifiers'
 
 /**
  * Error thrown when content file cannot be loaded.
@@ -89,6 +91,7 @@ export interface ContentProvider {
   loadOutcomeTier(ref: VersionRef): Promise<OutcomeTier>
   loadOutcomeArchetype(ref: VersionRef): Promise<OutcomeArchetype>
   loadPlayerClass(ref: VersionRef): Promise<PlayerClass>
+  loadChallengeModifier(ref: VersionRef): Promise<ChallengeModifier>
 }
 
 /**
@@ -145,6 +148,7 @@ export function createContentProvider(basePath = '/content'): ContentProvider {
     loadDelayedEffect: (ref) => loadContent<DelayedEffect>('delayed-effects', ref),
     loadOutcomeTier: (ref) => loadContent<OutcomeTier>('outcome-tiers', ref),
     loadOutcomeArchetype: (ref) => loadContent<OutcomeArchetype>('outcome-archetypes', ref),
-    loadPlayerClass: (ref) => loadContent<PlayerClass>('classes', ref)
+    loadPlayerClass: (ref) => loadContent<PlayerClass>('classes', ref),
+    loadChallengeModifier: (ref) => loadContent<ChallengeModifier>('challenge-modifiers', ref)
   }
 }

--- a/src/domains/content/services/manifest_validator.ts
+++ b/src/domains/content/services/manifest_validator.ts
@@ -23,6 +23,7 @@ const INVENTORY_KEYS: Array<keyof ContentPackInventory> = [
   'outcome_tiers',
   'outcome_archetypes',
   'classes',
+  'challenge_modifiers',
 ]
 
 function isObject(value: unknown): value is Record<string, unknown> {
@@ -113,9 +114,10 @@ export function validateContentPackManifest(input: unknown): ManifestValidationR
     })
   }
 
-  const entryPointFields: Array<keyof Pick<ContentPackManifest, 'scenarios' | 'classes' | 'tutorials'>> = [
+  const entryPointFields: Array<keyof Pick<ContentPackManifest, 'scenarios' | 'classes' | 'challenge_modifiers' | 'tutorials'>> = [
     'scenarios',
     'classes',
+    'challenge_modifiers',
     'tutorials',
   ]
 

--- a/src/domains/simulation/model/game_state.ts
+++ b/src/domains/simulation/model/game_state.ts
@@ -13,6 +13,8 @@ export interface RunMeta {
 export interface PlayerProfile {
   selected_class_ref?: VersionedContentRef
   display_name?: string
+  class_score_affinity?: string
+  challenge_modifier_ref?: VersionedContentRef
 }
 
 export interface ProgressState {
@@ -98,13 +100,15 @@ export interface CreateInitialGameStateInput {
   available_event_refs: VersionedContentRef[]
   selected_class_ref?: VersionedContentRef
   created_at_utc?: string
+  stakeholder_satisfaction_override?: number
 }
 
 export function createInitialGameState(input: CreateInitialGameStateInput): GameState {
   const stakeholders: StakeholderSnapshot = {}
+  const baseSatisfaction = input.stakeholder_satisfaction_override ?? 50
   for (const stakeholder_ref of input.stakeholder_refs) {
     stakeholders[stakeholder_ref.id] = {
-      satisfaction: 50
+      satisfaction: baseSatisfaction
     }
   }
 

--- a/src/domains/simulation/rules/classify_outcome_archetype.ts
+++ b/src/domains/simulation/rules/classify_outcome_archetype.ts
@@ -6,6 +6,11 @@ export type OutcomeArchetypeId =
   | 'runaway_refactorer'
   | 'firefighter'
   | 'system_stabilizer'
+  | 'the_diplomat'
+  | 'budget_hawk'
+  | 'the_pragmatist'
+  | 'the_visionary'
+  | 'burnout_machine'
 
 export interface ClassifyOutcomeArchetypeInput {
   game_state?: Pick<GameState, 'scores' | 'run_analytics'>
@@ -21,6 +26,7 @@ interface ArchetypeMetrics {
   events_pressure: number
   final_delivery_confidence: number
   final_budget: number
+  final_team_morale: number
 }
 
 const ARCHITECTURE_SCORE_IDS = ['domain_clarity', 'maintainability'] as const
@@ -60,6 +66,8 @@ function computeMetrics(
     (DEFAULT_STARTING_SCORE + (analytics.cumulative_score_deltas.delivery_confidence ?? 0))
   const finalBudget = scores?.budget ??
     (DEFAULT_STARTING_SCORE + (analytics.cumulative_score_deltas.budget ?? 0))
+  const finalTeamMorale = scores?.team_morale ??
+    (DEFAULT_STARTING_SCORE + (analytics.cumulative_score_deltas.team_morale ?? 0))
 
   return {
     architecture_delta: architectureDelta,
@@ -69,7 +77,8 @@ function computeMetrics(
     volatility_ratio: volatilityRatio,
     events_pressure: eventsPressure,
     final_delivery_confidence: finalDeliveryConfidence,
-    final_budget: finalBudget
+    final_budget: finalBudget,
+    final_team_morale: finalTeamMorale
   }
 }
 
@@ -127,6 +136,61 @@ function isRunawayRefactorer(metrics: ArchetypeMetrics): boolean {
 // System Stabilizer is the default fallback — no predicate needed.
 // Represents balanced or moderate play without a dominant strategic signal.
 
+/**
+ * Burnout Machine: shipped on time but the team is exhausted.
+ * Requires delivery to stay functional while team morale collapsed.
+ */
+function isBurnoutMachine(metrics: ArchetypeMetrics): boolean {
+  return (
+    metrics.final_team_morale < 30 &&
+    metrics.final_delivery_confidence >= 45
+  )
+}
+
+/**
+ * The Visionary: extreme architecture improvement, far beyond boundary_builder.
+ * Reshaped the entire domain model regardless of other outcomes.
+ */
+function isTheVisionary(metrics: ArchetypeMetrics): boolean {
+  return metrics.architecture_delta >= 30
+}
+
+/**
+ * The Diplomat: managed stakeholders exceptionally well under adversity.
+ * Requires strong stakeholder improvement during a turbulent run.
+ */
+function isTheDiplomat(metrics: ArchetypeMetrics): boolean {
+  return (
+    metrics.stakeholder_delta_total >= 15 &&
+    metrics.volatility_ratio >= 1.0
+  )
+}
+
+/**
+ * Budget Hawk: preserved and grew the budget while keeping delivery on track.
+ * Requires high final budget and positive delivery+budget trajectory.
+ */
+function isBudgetHawk(metrics: ArchetypeMetrics): boolean {
+  return (
+    metrics.final_budget >= 65 &&
+    metrics.delivery_and_budget_delta >= 5
+  )
+}
+
+/**
+ * The Pragmatist: moderate positive improvement across all dimensions.
+ * No single axis is extreme — balanced, steady improvement.
+ */
+function isThePragmatist(metrics: ArchetypeMetrics): boolean {
+  return (
+    metrics.architecture_delta >= 5 &&
+    metrics.architecture_delta < 20 &&
+    metrics.delivery_and_budget_delta >= -5 &&
+    metrics.stability_delta >= -5 &&
+    metrics.stakeholder_delta_total >= 0
+  )
+}
+
 export function classifyOutcomeArchetype(input: ClassifyOutcomeArchetypeInput): OutcomeArchetypeId {
   const analytics = input.run_analytics ?? input.game_state?.run_analytics
   if (!analytics) {
@@ -138,13 +202,30 @@ export function classifyOutcomeArchetype(input: ClassifyOutcomeArchetypeInput): 
 
   // Priority order:
   // 1. Firefighter — extreme chaos overshadows all other strategy signals
-  // 2. Boundary Builder — architecture focus WITH delivery discipline
-  // 3. Stakeholder Whisperer — people-focused strategy
-  // 4. Runaway Refactorer — architecture focus WITHOUT delivery discipline
-  // 5. System Stabilizer — balanced/moderate fallback
+  // 2. Burnout Machine — shipped but team destroyed (before delivery-positive archetypes)
+  // 3. The Visionary — extreme architecture (higher threshold than boundary_builder)
+  // 4. The Diplomat — managed stakeholders through adversity
+  // 5. Boundary Builder — architecture focus WITH delivery discipline
+  // 6. Stakeholder Whisperer — people-focused strategy
+  // 7. Budget Hawk — budget preservation focus
+  // 8. Runaway Refactorer — architecture focus WITHOUT delivery discipline
+  // 9. The Pragmatist — balanced positive improvement (catch-all before default)
+  // 10. System Stabilizer — balanced/moderate fallback
 
   if (isFirefighter(metrics)) {
     return 'firefighter'
+  }
+
+  if (isBurnoutMachine(metrics)) {
+    return 'burnout_machine'
+  }
+
+  if (isTheVisionary(metrics)) {
+    return 'the_visionary'
+  }
+
+  if (isTheDiplomat(metrics)) {
+    return 'the_diplomat'
   }
 
   if (isBoundaryBuilder(metrics)) {
@@ -155,8 +236,16 @@ export function classifyOutcomeArchetype(input: ClassifyOutcomeArchetypeInput): 
     return 'stakeholder_whisperer'
   }
 
+  if (isBudgetHawk(metrics)) {
+    return 'budget_hawk'
+  }
+
   if (isRunawayRefactorer(metrics)) {
     return 'runaway_refactorer'
+  }
+
+  if (isThePragmatist(metrics)) {
+    return 'the_pragmatist'
   }
 
   return 'system_stabilizer'

--- a/src/domains/simulation/services/create_run.ts
+++ b/src/domains/simulation/services/create_run.ts
@@ -12,9 +12,10 @@
  * - Create run analytics tracking
  */
 
-import { ScenarioBundle, versionRefKey } from '@/domains/content/model'
+import { ChallengeModifier, ScenarioBundle, versionRefKey } from '@/domains/content/model'
 import { VersionedContentRef } from '@/shared/contracts'
-import { CreateInitialGameStateInput, GameState, createInitialGameState } from '../model'
+import { createSeededRandom } from '@/shared/random/seeded_random'
+import { CreateInitialGameStateInput, GameState, ScoreSnapshot, createInitialGameState } from '../model'
 
 function toVersionedContentRef(ref: { id: string; version: number }): VersionedContentRef {
   return {
@@ -31,6 +32,20 @@ function hashSeed(seed: string): number {
   return Math.abs(hash)
 }
 
+function applyScoreVariance(
+  startingScores: ScoreSnapshot,
+  variance: number,
+  seed: string
+): ScoreSnapshot {
+  const random = createSeededRandom(`${seed}__score_variance`)
+  const result: ScoreSnapshot = {}
+  for (const [scoreId, baseValue] of Object.entries(startingScores)) {
+    const offset = random.nextInt(-variance, variance)
+    result[scoreId] = Math.max(0, Math.min(100, baseValue + offset))
+  }
+  return result
+}
+
 function createDeterministicRunId(scenarioBundle: ScenarioBundle, seed: string): string {
   const scenarioKey = versionRefKey({
     id: scenarioBundle.scenario.id,
@@ -45,17 +60,56 @@ function createDeterministicTimestamp(seed: string): string {
   return new Date(secondsSinceEpoch * 1000).toISOString()
 }
 
-export function createRun(scenarioBundle: ScenarioBundle, seed: string): GameState {
+function applyScoreAdjustments(
+  scores: ScoreSnapshot,
+  adjustments: Record<string, number>
+): ScoreSnapshot {
+  const result: ScoreSnapshot = { ...scores }
+  for (const [scoreId, adjustment] of Object.entries(adjustments)) {
+    if (scoreId in result) {
+      result[scoreId] = Math.max(0, Math.min(100, result[scoreId] + adjustment))
+    }
+  }
+  return result
+}
+
+export interface CreateRunOptions {
+  challenge_modifier?: ChallengeModifier
+}
+
+export function createRun(scenarioBundle: ScenarioBundle, seed: string, options?: CreateRunOptions): GameState {
+  const variance = scenarioBundle.scenario.score_variance ?? 0
+  let startingScores = variance > 0
+    ? applyScoreVariance(scenarioBundle.scenario.starting_scores, variance, seed)
+    : { ...scenarioBundle.scenario.starting_scores }
+
+  let maxTurns = scenarioBundle.scenario.max_turns
+  let stakeholderSatisfactionOverride: number | undefined
+
+  if (options?.challenge_modifier) {
+    const mod = options.challenge_modifier
+    if (mod.score_adjustments) {
+      startingScores = applyScoreAdjustments(startingScores, mod.score_adjustments)
+    }
+    if (mod.turn_adjustment) {
+      maxTurns = Math.max(1, maxTurns + mod.turn_adjustment)
+    }
+    if (mod.stakeholder_satisfaction_override != null) {
+      stakeholderSatisfactionOverride = mod.stakeholder_satisfaction_override
+    }
+  }
+
   const input: CreateInitialGameStateInput = {
     run_id: createDeterministicRunId(scenarioBundle, seed),
     seed,
     scenario_ref: toVersionedContentRef(scenarioBundle.scenario),
-    max_turns: scenarioBundle.scenario.max_turns,
-    starting_scores: scenarioBundle.scenario.starting_scores,
+    max_turns: maxTurns,
+    starting_scores: startingScores,
     stakeholder_refs: scenarioBundle.scenario.stakeholder_refs.map(toVersionedContentRef),
     available_action_refs: scenarioBundle.scenario.card_refs.map(toVersionedContentRef),
     available_event_refs: scenarioBundle.scenario.event_refs.map(toVersionedContentRef),
-    created_at_utc: createDeterministicTimestamp(seed)
+    created_at_utc: createDeterministicTimestamp(seed),
+    stakeholder_satisfaction_override: stakeholderSatisfactionOverride
   }
 
   return createInitialGameState(input)

--- a/src/domains/simulation/services/engine.ts
+++ b/src/domains/simulation/services/engine.ts
@@ -25,7 +25,7 @@
 import { ScenarioBundle } from '@/domains/content/model'
 import { createSeededRandom, SeededRandom } from '@/shared/random/seeded_random'
 import { GameState } from '../model'
-import { createRun } from './create_run'
+import { createRun, CreateRunOptions } from './create_run'
 import { RunOutcome, getRunOutcome } from './get_run_outcome'
 import { TurnBriefing, getTurnBriefing } from './get_turn_briefing'
 import { PlayTurnResult, playTurn } from './play_turn'
@@ -43,7 +43,7 @@ interface EngineStateContainer {
 }
 
 export interface SimulationEngine {
-  create_run(): GameState
+  create_run(options?: CreateRunOptions): GameState
   restore_run(game_state: GameState): GameState
   get_turn_briefing(): TurnBriefing
   play_turn(action_id: string): PlayTurnResult
@@ -72,8 +72,8 @@ export function create_engine(input: CreateEngineInput): SimulationEngine {
   }
 
   return {
-    create_run: () => {
-      engineState.game_state = createRun(engineState.scenario_bundle, engineState.seed)
+    create_run: (options?: CreateRunOptions) => {
+      engineState.game_state = createRun(engineState.scenario_bundle, engineState.seed, options)
       return engineState.game_state
     },
 

--- a/src/domains/simulation/services/play_turn.ts
+++ b/src/domains/simulation/services/play_turn.ts
@@ -116,7 +116,16 @@ export function playTurn(
     stakeholders: nextStakeholders
   })
 
-  nextScores = applyScoreChanges(nextScores, actionResult.score_changes, scenarioBundle)
+  // Class affinity bonus: +1 to the class's affinity score during action phase
+  const classAffinityBonus: ScoreChangeRecord[] = []
+  if (gameState.player_profile.class_score_affinity) {
+    classAffinityBonus.push({
+      score_id: gameState.player_profile.class_score_affinity,
+      delta: 1
+    })
+  }
+
+  nextScores = applyScoreChanges(nextScores, [...actionResult.score_changes, ...classAffinityBonus], scenarioBundle)
   nextStakeholders = applyStakeholderChanges(nextStakeholders, actionResult.stakeholder_changes)
 
   const eventResult = resolveEvent(gameState, scenarioBundle, random, {
@@ -138,6 +147,7 @@ export function playTurn(
   const allScoreChanges = [
     ...aftershocksResult.score_changes,
     ...actionResult.score_changes,
+    ...classAffinityBonus,
     ...eventResult.score_changes,
     ...stakeholderResult.score_changes
   ]

--- a/src/ui/components/results/outcome_panel.vue
+++ b/src/ui/components/results/outcome_panel.vue
@@ -46,7 +46,12 @@ const archetypeIcon = computed(() => {
     firefighter:          '🧯',
     runaway_refactorer:   '♻️',
     stakeholder_whisperer: '🗣️',
-    system_stabilizer:    '⚖️'
+    system_stabilizer:    '⚖️',
+    the_diplomat:         '🤝',
+    budget_hawk:          '🦅',
+    the_pragmatist:       '🔧',
+    the_visionary:        '🔭',
+    burnout_machine:      '🔥'
   }
   return icons[props.archetype]
 })

--- a/src/ui/components/results/share_result_card.vue
+++ b/src/ui/components/results/share_result_card.vue
@@ -153,7 +153,12 @@ const archetypeIcon = computed(() => {
     firefighter: '🧯',
     runaway_refactorer: '♻️',
     stakeholder_whisperer: '🗣️',
-    system_stabilizer: '⚖️'
+    system_stabilizer: '⚖️',
+    the_diplomat: '🤝',
+    budget_hawk: '🦅',
+    the_pragmatist: '🔧',
+    the_visionary: '🔭',
+    burnout_machine: '🔥'
   }
   return icons[props.payload.arch] ?? '🎯'
 })

--- a/src/ui/stores/game_store.ts
+++ b/src/ui/stores/game_store.ts
@@ -23,7 +23,7 @@ import type {
   PlayTurnResult,
   RunOutcome
 } from '@/domains/simulation'
-import type { ScenarioBundle, VersionRef, PlayerClass } from '@/domains/content/model'
+import type { ScenarioBundle, VersionRef, PlayerClass, ChallengeModifier } from '@/domains/content/model'
 import { buildScenarioBundle } from '@/domains/content'
 import type { ContentProvider } from '@/domains/content/services/content_provider'
 import { ContentPackRegistry } from '@/domains/content/services/content_pack_registry'
@@ -39,6 +39,7 @@ export interface RunSetupOptions {
   scenario_id: string
   scenario_version: number
   selected_class_ref?: VersionRef
+  selected_challenge_modifier_ref?: VersionRef
   character_name?: string
   seed?: string
   /** When true, loads content from the tutorial namespace */
@@ -80,6 +81,7 @@ export const useGameStore = defineStore('game', () => {
   
   // Available classes (loaded from content)
   const availableClasses = ref<PlayerClass[]>([])
+  const availableChallengeModifiers = ref<ChallengeModifier[]>([])
   const contentPackRegistry = ref<ContentPackRegistry | null>(null)
   
   // Computed
@@ -150,6 +152,20 @@ export const useGameStore = defineStore('game', () => {
     
     availableClasses.value = classes
   }
+
+  /**
+   * Load available challenge modifiers
+   */
+  async function load_available_challenge_modifiers() {
+    const provider = await get_merged_content_provider()
+    const modRefs: VersionRef[] = contentPackRegistry.value?.getAvailableChallengeModifiers() ?? []
+    
+    const mods = await Promise.all(
+      modRefs.map(ref => provider.loadChallengeModifier(ref))
+    )
+
+    availableChallengeModifiers.value = mods
+  }
   
   /**
    * Load available quests from the UI config and scenario content
@@ -199,16 +215,42 @@ export const useGameStore = defineStore('game', () => {
       const seed = options.seed || `seed-${Date.now()}`
       initialize_engine(bundle, seed)
       
-      // Create the run
+      // Create the run (with optional challenge modifier)
       if (!engine.value) {
         throw new Error('Engine not initialized')
       }
+
+      let challengeModifier
+      if (options.selected_challenge_modifier_ref) {
+        try {
+          challengeModifier = await provider.loadChallengeModifier(options.selected_challenge_modifier_ref)
+        } catch {
+          // Challenge modifier is optional — continue without it
+        }
+      }
       
-      const initialState = engine.value.create_run()
+      const initialState = engine.value.create_run(
+        challengeModifier ? { challenge_modifier: challengeModifier } : undefined
+      )
       
       // Apply optional profile settings
       if (options.selected_class_ref) {
         initialState.player_profile.selected_class_ref = options.selected_class_ref
+        // Resolve class score_affinity for gameplay bonus
+        try {
+          const playerClass = await provider.loadPlayerClass(options.selected_class_ref)
+          if (playerClass?.score_affinity) {
+            initialState.player_profile.class_score_affinity = playerClass.score_affinity
+          }
+        } catch {
+          // Class affinity is optional — continue without it
+        }
+      }
+      if (options.selected_challenge_modifier_ref) {
+        initialState.player_profile.challenge_modifier_ref = {
+          id: options.selected_challenge_modifier_ref.id,
+          version: options.selected_challenge_modifier_ref.version
+        }
       }
       if (options.character_name) {
         initialState.player_profile.display_name = options.character_name
@@ -429,6 +471,7 @@ export const useGameStore = defineStore('game', () => {
     availableQuests,
     availableTutorials,
     availableClasses,
+    availableChallengeModifiers,
     isAboutModalOpen,
     isRulesModalOpen,
     isIntroSplashOpen,
@@ -454,6 +497,7 @@ export const useGameStore = defineStore('game', () => {
     load_available_quests,
     load_available_tutorials,
     load_available_classes,
+    load_available_challenge_modifiers,
     start_new_run,
     refresh_turn_briefing,
     play_turn,

--- a/src/ui/views/end_of_run_view.vue
+++ b/src/ui/views/end_of_run_view.vue
@@ -295,7 +295,12 @@ function getArchetypeIcon(archetype: OutcomeArchetypeId): string {
     'firefighter': '🧯',
     'runaway_refactorer': '♻️',
     'stakeholder_whisperer': '🗣️',
-    'system_stabilizer': '⚖️'
+    'system_stabilizer': '⚖️',
+    'the_diplomat': '🤝',
+    'budget_hawk': '🦅',
+    'the_pragmatist': '🔧',
+    'the_visionary': '🔭',
+    'burnout_machine': '🔥'
   }
   return icons[archetype] || '🎯'
 }
@@ -306,7 +311,12 @@ function getArchetypeDescription(archetype: OutcomeArchetypeId): string {
     'firefighter': 'You responded swiftly to immediate crises and kept the system running under pressure, saving the day when it mattered most.',
     'runaway_refactorer': 'You pursued aggressive refactoring and technical excellence, sometimes at the cost of delivery speed.',
     'stakeholder_whisperer': 'You skillfully navigated organizational politics and stakeholder relationships, building consensus for change.',
-    'system_stabilizer': 'You brought balance and stability to a chaotic system, carefully managing competing priorities.'
+    'system_stabilizer': 'You brought balance and stability to a chaotic system, carefully managing competing priorities.',
+    'the_diplomat': 'You kept every stakeholder at the table, even when the system was on fire.',
+    'budget_hawk': 'You proved that good architecture doesn\'t have to break the bank.',
+    'the_pragmatist': 'You balanced short-term fixes with long-term investments, never going to extremes.',
+    'the_visionary': 'You saw the big picture and reshaped the domain, even when others couldn\'t see why it mattered.',
+    'burnout_machine': 'You shipped everything on time, but at what cost? The team is exhausted.'
   }
   return descriptions[archetype] || 'Your architectural journey was unique and shaped by the choices you made.'
 }

--- a/src/ui/views/game_view.vue
+++ b/src/ui/views/game_view.vue
@@ -38,6 +38,21 @@
       @startRealGame="handleStartRealGame"
     />
 
+    <SurfaceModalPanel
+      :is-open="isScenarioInfoOpen"
+      :title="scenario?.name ?? 'Scenario'"
+      size="md"
+      @close="isScenarioInfoOpen = false"
+    >
+      <div class="scenario-info-body">
+        <p v-if="scenario?.description" class="scenario-info-desc">{{ scenario.description }}</p>
+        <p v-if="scenario?.flavor_text" class="scenario-info-flavor">"{{ scenario.flavor_text }}"</p>
+      </div>
+      <template #footer>
+        <AppButton variant="primary" @click="isScenarioInfoOpen = false">Got it!</AppButton>
+      </template>
+    </SurfaceModalPanel>
+
     <GameMasthead
       @show-rules="gameStore.openRulesModal"
       @show-about="gameStore.openAboutModal"
@@ -54,6 +69,17 @@
       <header class="play-header">
         <div class="header-row">
           <p class="turn-pill">Turn {{ gameStore.currentTurn }} / {{ gameStore.maxTurns }}</p>
+
+          <button
+            v-if="scenario?.name"
+            class="scenario-pill"
+            @click="isScenarioInfoOpen = true"
+            :title="'View scenario info: ' + scenario.name"
+          >
+            <span class="scenario-pill-icon">📜</span>
+            <span class="scenario-pill-name">{{ scenario.name }}</span>
+            <span class="scenario-pill-info">ⓘ</span>
+          </button>
 
           <!-- Action / aftershock indicators — always visible -->
           <div class="header-indicators" v-if="gameStore.turnBriefing && !gameStore.isRunComplete">
@@ -374,6 +400,7 @@ import ScoreHud from '@/ui/components/scores/score_hud.vue'
 import SceneStage from '@/ui/components/gameplay/scene_stage.vue'
 import SatchelToggleButton from '@/ui/components/cards/satchel_toggle_button.vue'
 import GameHudSidebar from '@/ui/components/common/game_hud_sidebar.vue'
+import SurfaceModalPanel from '@/ui/components/surfaces/surface_modal_panel.vue'
 import AppButton from '@/ui/components/common/AppButton.vue'
 import IconSpell from '@/ui/components/icons/IconSpell.vue'
 import {
@@ -391,6 +418,7 @@ const modalCardId = ref<string | null>(null)
 const isSatchelOpen = ref(false)
 const resolutionPopupOpen = ref(false)
 const isResolutionExpanded = ref(false)
+const isScenarioInfoOpen = ref(false)
 const activeEffectsPopupOpen = ref(false)
 const randomSceneId = ref<SceneBackgroundId>(pickRandomSceneId())
 const randomAvatarRoles = ref<AvatarRoleId[]>(shuffleAvatarRoles())
@@ -687,6 +715,72 @@ function goToEndScreen() {
   border-radius: 999px;
   padding: 0.25rem 0.55rem;
   background: rgba(255, 255, 255, 0.04);
+}
+
+.scenario-pill {
+  all: unset;
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  border: 1px solid color-mix(in oklab, var(--dng-bronze-mid, #a07018), transparent 50%);
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  background: rgba(160, 112, 24, 0.08);
+  color: var(--text-warm, #c4a96a);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.scenario-pill:hover {
+  background: rgba(160, 112, 24, 0.18);
+  border-color: color-mix(in oklab, var(--dng-bronze-mid, #a07018), transparent 25%);
+}
+
+.scenario-pill:focus-visible {
+  outline: 2px solid var(--border-focus, rgba(38, 212, 185, 0.70));
+  outline-offset: 2px;
+}
+
+.scenario-pill-icon {
+  font-size: 0.85em;
+}
+
+.scenario-pill-name {
+  max-width: 18ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.scenario-pill-info {
+  font-size: 0.8em;
+  opacity: 0.6;
+}
+
+.scenario-info-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 0.5rem 0;
+}
+
+.scenario-info-desc {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  line-height: 1.6;
+}
+
+.scenario-info-flavor {
+  margin: 0;
+  color: var(--text-dim);
+  font-style: italic;
+  font-size: var(--text-sm);
+  border-left: 2px solid var(--border-subtle);
+  padding-left: 0.8rem;
 }
 
 .header-indicators {

--- a/src/ui/views/run_setup_view.vue
+++ b/src/ui/views/run_setup_view.vue
@@ -230,25 +230,67 @@
             <p>Loading modifiers...</p>
           </div>
           
-          <div v-else class="modifier-grid">
+          <div v-else class="modifier-layout">
+            <!-- None toggle — always visible, visually separated -->
             <button
-              class="modifier-chip"
-              :class="{ selected: selectedModifier === null }"
+              class="modifier-none-btn"
+              :class="{ active: selectedModifier === null }"
               @click="selectedModifier = null"
             >
-              <span class="modifier-chip-name">None</span>
-              <span class="modifier-chip-desc">Standard difficulty</span>
+              <svg class="modifier-none-icon" viewBox="0 0 16 16" aria-hidden="true">
+                <circle cx="8" cy="8" r="6" stroke="currentColor" fill="none" stroke-width="1.4"/>
+                <line x1="4" y1="12" x2="12" y2="4" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+              </svg>
+              <span class="modifier-none-label">No Modifier</span>
+              <span class="modifier-none-hint">Standard difficulty</span>
             </button>
-            <button
-              v-for="modifier in availableModifiers"
-              :key="modifier.id"
-              class="modifier-chip"
-              :class="{ selected: selectedModifier?.id === modifier.id }"
-              @click="selectModifier(modifier)"
-            >
-              <span class="modifier-chip-name">{{ modifier.name }}</span>
-              <span class="modifier-chip-desc">{{ modifier.description }}</span>
-            </button>
+
+            <!-- Modifier chips -->
+            <div class="modifier-grid">
+              <button
+                v-for="modifier in availableModifiers"
+                :key="modifier.id"
+                class="modifier-chip"
+                :class="{ selected: selectedModifier?.id === modifier.id }"
+                @click="selectModifier(modifier)"
+              >
+                <!-- Fire sparkle SVG — visible when selected -->
+                <svg
+                  v-if="selectedModifier?.id === modifier.id"
+                  class="modifier-fire-svg"
+                  viewBox="0 0 40 40"
+                  aria-hidden="true"
+                >
+                  <!-- Central flame -->
+                  <path d="M20,6 C20,6 26,14 26,22 C26,28 23,32 20,34 C17,32 14,28 14,22 C14,14 20,6 20,6Z"
+                        fill="url(#flame-grad)" opacity="0.85"/>
+                  <!-- Inner core -->
+                  <path d="M20,16 C20,16 23,20 23,24 C23,27 21.5,29 20,30 C18.5,29 17,27 17,24 C17,20 20,16 20,16Z"
+                        fill="url(#flame-core)" opacity="0.9"/>
+                  <!-- Spark particles -->
+                  <circle cx="12" cy="12" r="1.2" fill="#ffd54f" opacity="0.8" class="spark spark-1"/>
+                  <circle cx="28" cy="10" r="1" fill="#ffab40" opacity="0.7" class="spark spark-2"/>
+                  <circle cx="10" cy="22" r="0.8" fill="#ffd54f" opacity="0.6" class="spark spark-3"/>
+                  <circle cx="30" cy="20" r="1.1" fill="#ff8f00" opacity="0.7" class="spark spark-4"/>
+                  <circle cx="16" cy="8" r="0.7" fill="#fff176" opacity="0.9" class="spark spark-5"/>
+                  <circle cx="25" cy="15" r="0.9" fill="#ffcc02" opacity="0.8" class="spark spark-6"/>
+                  <defs>
+                    <linearGradient id="flame-grad" x1="0" y1="1" x2="0" y2="0">
+                      <stop offset="0%" stop-color="#ff6f00"/>
+                      <stop offset="50%" stop-color="#ff8f00"/>
+                      <stop offset="100%" stop-color="#ffd54f"/>
+                    </linearGradient>
+                    <radialGradient id="flame-core" cx="50%" cy="70%" r="50%">
+                      <stop offset="0%" stop-color="#fff9c4"/>
+                      <stop offset="100%" stop-color="#ffab40"/>
+                    </radialGradient>
+                  </defs>
+                </svg>
+
+                <span class="modifier-chip-name">{{ modifier.name }}</span>
+                <span class="modifier-chip-desc">{{ modifier.description }}</span>
+              </button>
+            </div>
           </div>
         </section>
         
@@ -752,6 +794,57 @@ async function launchTutorial(quest: QuestDisplayModel) {
   gap: var(--space-lg);
 }
 
+/* Modifier layout */
+.modifier-layout {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.modifier-none-btn {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-lg);
+  border: 1px solid var(--border-card);
+  border-radius: var(--radius-lg);
+  background: var(--surface-card);
+  cursor: pointer;
+  transition: border-color var(--transition-base), background var(--transition-base);
+}
+
+.modifier-none-btn:hover {
+  border-color: var(--border-hover);
+}
+
+.modifier-none-btn.active {
+  border-color: color-mix(in oklab, var(--color-accent, #26d4b9), transparent 30%);
+  background: color-mix(in oklab, var(--color-accent, #26d4b9), transparent 92%);
+}
+
+.modifier-none-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  color: var(--color-text-muted);
+}
+
+.modifier-none-btn.active .modifier-none-icon {
+  color: var(--color-accent, #26d4b9);
+}
+
+.modifier-none-label {
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
+}
+
+.modifier-none-hint {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  margin-left: auto;
+}
+
 /* Modifier grid */
 .modifier-grid {
   display: flex;
@@ -760,6 +853,7 @@ async function launchTutorial(quest: QuestDisplayModel) {
 }
 
 .modifier-chip {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
@@ -769,9 +863,10 @@ async function launchTutorial(quest: QuestDisplayModel) {
   background: var(--surface-card);
   cursor: pointer;
   text-align: left;
-  transition: border-color var(--transition-base), box-shadow var(--transition-base);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
   min-width: 160px;
   max-width: 240px;
+  overflow: hidden;
 }
 
 .modifier-chip:hover {
@@ -779,14 +874,86 @@ async function launchTutorial(quest: QuestDisplayModel) {
 }
 
 .modifier-chip.selected {
-  border-color: var(--color-accent);
-  box-shadow: 0 0 0 1px var(--color-accent);
+  border-color: #ff8f00;
+  box-shadow:
+    0 0 0 1px #ff8f00,
+    0 0 12px rgba(255, 143, 0, 0.25),
+    0 0 24px rgba(255, 111, 0, 0.12);
+  background: linear-gradient(
+    170deg,
+    rgba(255, 143, 0, 0.08) 0%,
+    rgba(255, 111, 0, 0.04) 40%,
+    var(--surface-card) 100%
+  );
+  animation: modifier-glow-pulse 2.5s ease-in-out infinite;
+}
+
+/* Fire SVG overlay */
+.modifier-fire-svg {
+  position: absolute;
+  top: -6px;
+  right: -4px;
+  width: 40px;
+  height: 40px;
+  pointer-events: none;
+  animation: flame-flicker 1.8s ease-in-out infinite;
+}
+
+/* Spark particle animations */
+.spark { animation-duration: 2s; animation-iteration-count: infinite; }
+.spark-1 { animation-name: spark-float-1; }
+.spark-2 { animation-name: spark-float-2; }
+.spark-3 { animation-name: spark-float-3; }
+.spark-4 { animation-name: spark-float-4; }
+.spark-5 { animation-name: spark-float-5; }
+.spark-6 { animation-name: spark-float-6; }
+
+@keyframes flame-flicker {
+  0%, 100% { transform: scaleY(1) translateY(0); opacity: 0.85; }
+  25% { transform: scaleY(1.06) translateY(-1px); opacity: 1; }
+  50% { transform: scaleY(0.95) translateY(1px); opacity: 0.8; }
+  75% { transform: scaleY(1.03) translateY(-0.5px); opacity: 0.92; }
+}
+
+@keyframes spark-float-1 {
+  0%, 100% { transform: translate(0, 0); opacity: 0.8; }
+  50% { transform: translate(-2px, -4px); opacity: 0.3; }
+}
+@keyframes spark-float-2 {
+  0%, 100% { transform: translate(0, 0); opacity: 0.7; }
+  50% { transform: translate(3px, -5px); opacity: 0.2; }
+}
+@keyframes spark-float-3 {
+  0%, 100% { transform: translate(0, 0); opacity: 0.6; }
+  50% { transform: translate(-3px, -3px); opacity: 0.2; }
+}
+@keyframes spark-float-4 {
+  0%, 100% { transform: translate(0, 0); opacity: 0.7; }
+  50% { transform: translate(2px, -4px); opacity: 0.3; }
+}
+@keyframes spark-float-5 {
+  0%, 100% { transform: translate(0, 0); opacity: 0.9; }
+  50% { transform: translate(-1px, -5px); opacity: 0.2; }
+}
+@keyframes spark-float-6 {
+  0%, 100% { transform: translate(0, 0); opacity: 0.8; }
+  50% { transform: translate(2px, -3px); opacity: 0.3; }
+}
+
+@keyframes modifier-glow-pulse {
+  0%, 100% { box-shadow: 0 0 0 1px #ff8f00, 0 0 12px rgba(255, 143, 0, 0.25), 0 0 24px rgba(255, 111, 0, 0.12); }
+  50% { box-shadow: 0 0 0 1px #ff8f00, 0 0 18px rgba(255, 143, 0, 0.35), 0 0 32px rgba(255, 111, 0, 0.18); }
+}
+
+.modifier-chip.selected .modifier-chip-name {
+  color: #ffab40;
 }
 
 .modifier-chip-name {
   font-weight: var(--font-weight-semibold);
   color: var(--color-text-primary);
   font-size: var(--font-size-sm);
+  transition: color 0.2s ease;
 }
 
 .modifier-chip-desc {

--- a/src/ui/views/run_setup_view.vue
+++ b/src/ui/views/run_setup_view.vue
@@ -172,7 +172,7 @@
               </svg>
               Choose Your Class
             </h2>
-            <p class="section-hint">Your architectural archetype (cosmetic for MVP)</p>
+            <p class="section-hint">Your architectural archetype — each class gives +1 to its affinity score per turn</p>
           </div>
           
           <div v-if="isLoadingClasses" class="loading-state">
@@ -212,6 +212,45 @@
             :maxlength="50"
           />
         </section>
+
+        <!-- Challenge Modifier (optional) -->
+        <section class="setup-section modifier-section">
+          <div class="section-header">
+            <h2 class="section-title">
+              <svg class="section-icon-svg" viewBox="0 0 20 20" aria-hidden="true">
+                <path d="M10,2 L12,7 L17,7 L13,11 L15,17 L10,13 L5,17 L7,11 L3,7 L8,7 Z" stroke="currentColor" fill="none" stroke-width="1.4" stroke-linejoin="round"/>
+              </svg>
+              Challenge Mode
+            </h2>
+            <p class="section-hint">Optional — add a difficulty modifier for extra challenge</p>
+          </div>
+          
+          <div v-if="isLoadingModifiers" class="loading-state">
+            <div class="loading-spinner"></div>
+            <p>Loading modifiers...</p>
+          </div>
+          
+          <div v-else class="modifier-grid">
+            <button
+              class="modifier-chip"
+              :class="{ selected: selectedModifier === null }"
+              @click="selectedModifier = null"
+            >
+              <span class="modifier-chip-name">None</span>
+              <span class="modifier-chip-desc">Standard difficulty</span>
+            </button>
+            <button
+              v-for="modifier in availableModifiers"
+              :key="modifier.id"
+              class="modifier-chip"
+              :class="{ selected: selectedModifier?.id === modifier.id }"
+              @click="selectModifier(modifier)"
+            >
+              <span class="modifier-chip-name">{{ modifier.name }}</span>
+              <span class="modifier-chip-desc">{{ modifier.description }}</span>
+            </button>
+          </div>
+        </section>
         
         <!-- Action Buttons -->
         <div class="actions-section">
@@ -240,7 +279,7 @@
 import { ref, onMounted, onUnmounted, watch, computed } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useGameStore } from '@/ui/stores/game_store'
-import type { PlayerClass } from '@/domains/content/model'
+import type { PlayerClass, ChallengeModifier } from '@/domains/content/model'
 import type { QuestDisplayModel } from '@/ui/types/quest_display_model'
 import AboutModal from '@/ui/components/common/about_modal.vue'
 import RulesModal from '@/ui/components/common/rules_modal.vue'
@@ -260,6 +299,8 @@ const gameStore = useGameStore()
 
 const selectedClass = ref<PlayerClass | null>(null)
 const selectedQuest = ref<QuestDisplayModel | null>(null)
+const selectedModifier = ref<ChallengeModifier | null>(null)
+const availableModifiers = ref<ChallengeModifier[]>([])
 const characterName = ref('')
 
 const isMobile = ref(false)
@@ -291,6 +332,7 @@ const activeTabIndex = computed({
 const isLoadingClasses = ref(false)
 const isLoadingQuests = ref(false)
 const isLoadingTutorials = ref(false)
+const isLoadingModifiers = ref(false)
 
 onMounted(async () => {
   // Load available classes if not already loaded
@@ -321,6 +363,17 @@ onMounted(async () => {
     } finally {
       isLoadingQuests.value = false
     }
+  }
+
+  // Load available challenge modifiers
+  isLoadingModifiers.value = true
+  try {
+    await gameStore.load_available_challenge_modifiers()
+    availableModifiers.value = gameStore.availableChallengeModifiers
+  } catch {
+    // Challenge modifiers are optional
+  } finally {
+    isLoadingModifiers.value = false
   }
 
   // Handle tutorial query param from welcome page
@@ -363,6 +416,10 @@ function selectQuest(quest: QuestDisplayModel) {
   selectedQuest.value = quest
 }
 
+function selectModifier(modifier: ChallengeModifier) {
+  selectedModifier.value = modifier
+}
+
 function goBack() {
   router.push('/')
 }
@@ -377,6 +434,10 @@ async function startRun() {
       id: selectedClass.value.id,
       version: selectedClass.value.version
     },
+    selected_challenge_modifier_ref: selectedModifier.value ? {
+      id: selectedModifier.value.id,
+      version: selectedModifier.value.version
+    } : undefined,
     character_name: characterName.value || undefined,
     is_tutorial: selectedQuest.value.isTutorial ?? false
   })
@@ -689,6 +750,49 @@ async function launchTutorial(quest: QuestDisplayModel) {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   gap: var(--space-lg);
+}
+
+/* Modifier grid */
+.modifier-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+}
+
+.modifier-chip {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding: var(--space-md) var(--space-lg);
+  border: 1px solid var(--border-card);
+  border-radius: var(--radius-lg);
+  background: var(--surface-card);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color var(--transition-base), box-shadow var(--transition-base);
+  min-width: 160px;
+  max-width: 240px;
+}
+
+.modifier-chip:hover {
+  border-color: var(--border-hover);
+}
+
+.modifier-chip.selected {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 1px var(--color-accent);
+}
+
+.modifier-chip-name {
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
+}
+
+.modifier-chip-desc {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  line-height: 1.3;
 }
 
 /* Action Buttons */

--- a/stories/mocks/outcomes.ts
+++ b/stories/mocks/outcomes.ts
@@ -37,5 +37,35 @@ export const outcomeMocks: Record<OutcomeArchetypeId, OutcomeMock> = {
     title: 'Runaway Refactorer',
     summary: 'You chased deep cleanup aggressively, sometimes outrunning delivery expectations.',
     mood: 'tense'
+  },
+  the_diplomat: {
+    archetype: 'the_diplomat',
+    title: 'The Diplomat',
+    summary: 'You navigated conflicting stakeholder demands with grace and compromise.',
+    mood: 'calm'
+  },
+  budget_hawk: {
+    archetype: 'budget_hawk',
+    title: 'Budget Hawk',
+    summary: 'You kept costs under control, sometimes at the expense of team comfort.',
+    mood: 'tense'
+  },
+  the_pragmatist: {
+    archetype: 'the_pragmatist',
+    title: 'The Pragmatist',
+    summary: 'You made practical tradeoffs that kept the project moving forward.',
+    mood: 'calm'
+  },
+  the_visionary: {
+    archetype: 'the_visionary',
+    title: 'The Visionary',
+    summary: 'You pushed for ambitious long-term improvements despite short-term costs.',
+    mood: 'victorious'
+  },
+  burnout_machine: {
+    archetype: 'burnout_machine',
+    title: 'Burnout Machine',
+    summary: 'You pushed through at an unsustainable pace, wearing the team thin.',
+    mood: 'tense'
   }
 }

--- a/tests/content/balance_pass_a.test.ts
+++ b/tests/content/balance_pass_a.test.ts
@@ -63,9 +63,9 @@ describe('Balance pass A — telemetry-informed tuning', () => {
       const provider = createFileContentProvider(contentRoot)
       const scenario = await provider.loadScenario({ id: 'compliance_gauntlet', version: 1 })
 
-      expect(scenario.starting_scores.delivery_confidence).toBe(45)
+      expect(scenario.starting_scores.delivery_confidence).toBe(38)
       expect(scenario.starting_scores.user_trust).toBe(55)
-      expect(scenario.starting_scores.team_morale).toBe(40)
+      expect(scenario.starting_scores.team_morale).toBe(32)
       expect(scenario.starting_scores.maintainability).toBe(44)
     })
 
@@ -75,7 +75,7 @@ describe('Balance pass A — telemetry-informed tuning', () => {
 
       expect(scenario.max_turns).toBe(10)
       expect(scenario.starting_scores.delivery_confidence).toBe(50)
-      expect(scenario.starting_scores.budget).toBe(65)
+      expect(scenario.starting_scores.budget).toBe(58)
     })
 
     it('monolith_of_mild_despair includes align_budget_with_architecture', async () => {
@@ -89,8 +89,8 @@ describe('Balance pass A — telemetry-informed tuning', () => {
       const provider = createFileContentProvider(contentRoot)
       const scenario = await provider.loadScenario({ id: 'startup_hypergrowth', version: 1 })
 
-      expect(scenario.starting_scores.budget).toBe(75)
-      expect(scenario.starting_scores.team_morale).toBe(65)
+      expect(scenario.starting_scores.budget).toBe(58)
+      expect(scenario.starting_scores.team_morale).toBe(50)
     })
 
     it('microservice_sprawl has slightly higher starting user_trust', async () => {

--- a/tests/content/balance_pass_a.test.ts
+++ b/tests/content/balance_pass_a.test.ts
@@ -89,8 +89,8 @@ describe('Balance pass A — telemetry-informed tuning', () => {
       const provider = createFileContentProvider(contentRoot)
       const scenario = await provider.loadScenario({ id: 'startup_hypergrowth', version: 1 })
 
-      expect(scenario.starting_scores.budget).toBe(58)
-      expect(scenario.starting_scores.team_morale).toBe(50)
+      expect(scenario.starting_scores.budget).toBe(53)
+      expect(scenario.starting_scores.team_morale).toBe(45)
     })
 
     it('microservice_sprawl has slightly higher starting user_trust', async () => {

--- a/tests/content/balance_pass_a.test.ts
+++ b/tests/content/balance_pass_a.test.ts
@@ -17,7 +17,7 @@ import { ContentProvider } from '@/domains/content/services/content_provider'
 import { buildScenarioBundle } from '@/domains/content/services/bundle_builder'
 import { assertValidBundle } from '@/domains/content/services/bundle_validator'
 import { simulate_runs } from '@/domains/simulation/services/simulation_runner'
-import { PlayerClass } from '@/domains/content/model/content_types'
+import { PlayerClass, ChallengeModifier } from '@/domains/content/model/content_types'
 
 function createFileContentProvider(contentRoot: string): ContentProvider {
   async function loadJson<T extends { id: string; version: number }>(
@@ -49,7 +49,8 @@ function createFileContentProvider(contentRoot: string): ContentProvider {
     loadDelayedEffect: (ref) => loadJson<DelayedEffect>('delayed-effects', ref),
     loadOutcomeTier: (ref) => loadJson<OutcomeTier>('outcome-tiers', ref),
     loadOutcomeArchetype: (ref) => loadJson<OutcomeArchetype>('outcome-archetypes', ref),
-    loadPlayerClass: (ref) => loadJson<PlayerClass>('classes', ref)
+    loadPlayerClass: (ref) => loadJson<PlayerClass>('classes', ref),
+    loadChallengeModifier: (ref) => loadJson<ChallengeModifier>('challenge-modifiers', ref)
   }
 }
 

--- a/tests/content/content_expansion_pass_a.test.ts
+++ b/tests/content/content_expansion_pass_a.test.ts
@@ -50,6 +50,9 @@ function createFileContentProvider(contentRoot: string): ContentProvider {
     loadOutcomeArchetype: (ref) => loadJson<OutcomeArchetype>('outcome-archetypes', ref),
     loadPlayerClass: async (_ref) => {
       throw new Error('Player class loading is not required for scenario bundle construction')
+    },
+    loadChallengeModifier: async (_ref) => {
+      throw new Error('Challenge modifier loading is not required for scenario bundle construction')
     }
   }
 }

--- a/tests/content/content_expansion_pass_b.test.ts
+++ b/tests/content/content_expansion_pass_b.test.ts
@@ -20,7 +20,7 @@ import {
   parseConditionDescription
 } from '@/domains/simulation/rules/condition_evaluator'
 import { simulate_runs } from '@/domains/simulation/services/simulation_runner'
-import { PlayerClass } from '@/domains/content/model/content_types'
+import { PlayerClass, ChallengeModifier } from '@/domains/content/model/content_types'
 
 function createFileContentProvider(contentRoot: string): ContentProvider {
   async function loadJson<T extends { id: string; version: number }>(
@@ -52,7 +52,8 @@ function createFileContentProvider(contentRoot: string): ContentProvider {
     loadDelayedEffect: (ref) => loadJson<DelayedEffect>('delayed-effects', ref),
     loadOutcomeTier: (ref) => loadJson<OutcomeTier>('outcome-tiers', ref),
     loadOutcomeArchetype: (ref) => loadJson<OutcomeArchetype>('outcome-archetypes', ref),
-    loadPlayerClass: (ref) => loadJson<PlayerClass>('classes', ref)
+    loadPlayerClass: (ref) => loadJson<PlayerClass>('classes', ref),
+    loadChallengeModifier: (ref) => loadJson<ChallengeModifier>('challenge-modifiers', ref)
   }
 }
 

--- a/tests/content/content_pack_integration.test.ts
+++ b/tests/content/content_pack_integration.test.ts
@@ -14,6 +14,7 @@ import type {
   StakeholderReactionRule,
   VersionRef,
   PlayerClass,
+  ChallengeModifier,
 } from '@/domains/content/model'
 import type { ContentProvider } from '@/domains/content/services/content_provider'
 import { buildScenarioBundle } from '@/domains/content/services/bundle_builder'
@@ -58,6 +59,7 @@ function createFileContentProvider(contentRoot: string): ContentProvider {
     loadOutcomeTier: (ref: VersionRef) => loadJson<OutcomeTier>(contentRoot, 'outcome-tiers', ref),
     loadOutcomeArchetype: (ref: VersionRef) => loadJson<OutcomeArchetype>(contentRoot, 'outcome-archetypes', ref),
     loadPlayerClass: (ref: VersionRef) => loadJson<PlayerClass>(contentRoot, 'classes', ref),
+    loadChallengeModifier: (ref: VersionRef) => loadJson<ChallengeModifier>(contentRoot, 'challenge-modifiers', ref),
   }
 }
 

--- a/tests/content/content_pack_manifest.test.ts
+++ b/tests/content/content_pack_manifest.test.ts
@@ -19,6 +19,7 @@ function createValidManifest(overrides: Partial<ContentPackManifest> = {}): Cont
     pack_homepage_url: 'https://example.com/pack',
     scenarios: [{ id: 'monolith_of_mild_despair', version: 1 }],
     classes: [{ id: 'boundary_mage', version: 1 }],
+    challenge_modifiers: [],
     tutorials: [],
     content: {
       scenarios: ['monolith_of_mild_despair-v1.json'],
@@ -31,6 +32,7 @@ function createValidManifest(overrides: Partial<ContentPackManifest> = {}): Cont
       outcome_tiers: ['success-v1.json'],
       outcome_archetypes: ['boundary_builder-v1.json'],
       classes: ['boundary_mage-v1.json'],
+      challenge_modifiers: [],
     },
     ...overrides,
   }

--- a/tests/content/content_pack_registry.test.ts
+++ b/tests/content/content_pack_registry.test.ts
@@ -12,6 +12,7 @@ import type {
   StakeholderReactionRule,
   VersionRef,
   PlayerClass,
+  ChallengeModifier,
 } from '@/domains/content/model'
 import type { ContentProvider } from '@/domains/content/services/content_provider'
 import { ContentPackRegistry } from '@/domains/content/services/content_pack_registry'
@@ -28,6 +29,7 @@ function createManifest(overrides: Partial<ContentPackManifest>): ContentPackMan
     authors: [{ name: 'Test Author' }],
     scenarios: [],
     classes: [],
+    challenge_modifiers: [],
     tutorials: [],
     content: {
       scenarios: [],
@@ -40,6 +42,7 @@ function createManifest(overrides: Partial<ContentPackManifest>): ContentPackMan
       outcome_tiers: [],
       outcome_archetypes: [],
       classes: [],
+      challenge_modifiers: [],
     },
     ...overrides,
   }
@@ -134,6 +137,13 @@ function createMockProvider(label: string): ContentProvider {
     description: label,
   })
 
+  const makeChallengeModifier = (ref: VersionRef): ChallengeModifier => ({
+    id: ref.id,
+    version: ref.version,
+    name: `${label}-modifier`,
+    description: label,
+  })
+
   return {
     loadScenario: vi.fn(async (ref: VersionRef) => makeScenario(ref)),
     loadScore: vi.fn(async (ref: VersionRef) => makeScore(ref)),
@@ -145,6 +155,7 @@ function createMockProvider(label: string): ContentProvider {
     loadOutcomeTier: vi.fn(async (ref: VersionRef) => makeOutcomeTier(ref)),
     loadOutcomeArchetype: vi.fn(async (ref: VersionRef) => makeOutcomeArchetype(ref)),
     loadPlayerClass: vi.fn(async (ref: VersionRef) => makePlayerClass(ref)),
+    loadChallengeModifier: vi.fn(async (ref: VersionRef) => makeChallengeModifier(ref)),
   }
 }
 
@@ -199,6 +210,7 @@ describe('content pack registry', () => {
         outcome_tiers: [],
         outcome_archetypes: [],
         classes: [],
+        challenge_modifiers: [],
       },
     })
 
@@ -215,6 +227,7 @@ describe('content pack registry', () => {
         outcome_tiers: [],
         outcome_archetypes: [],
         classes: [],
+        challenge_modifiers: [],
       },
     })
 

--- a/tests/content/mvp_content_pack.test.ts
+++ b/tests/content/mvp_content_pack.test.ts
@@ -101,12 +101,12 @@ describe('MVP content pack', () => {
     expect(bundle.scenario.max_turns).toBe(10)
     expect(bundle.scores.size).toBe(6)
     expect(bundle.stakeholders.size).toBe(4)
-    expect(bundle.stakeholder_reaction_rules.size).toBe(12)
-    expect(bundle.cards.size).toBe(21)
-    expect(bundle.events.size).toBe(6)
-    expect(bundle.delayed_effects.size).toBe(9)
+    expect(bundle.stakeholder_reaction_rules.size).toBe(19)
+    expect(bundle.cards.size).toBe(26)
+    expect(bundle.events.size).toBe(11)
+    expect(bundle.delayed_effects.size).toBe(12)
     expect(bundle.outcome_tiers.size).toBe(5)
-    expect(bundle.outcome_archetypes.size).toBe(5)
+    expect(bundle.outcome_archetypes.size).toBe(10)
   })
 
   it('loads mixed card availability profiles from authored content', async () => {

--- a/tests/content/mvp_content_pack.test.ts
+++ b/tests/content/mvp_content_pack.test.ts
@@ -84,6 +84,9 @@ function createFileContentProvider(contentRoot: string): ContentProvider {
     loadOutcomeArchetype: (ref) => loadJson<OutcomeArchetype>('outcome-archetypes', ref),
     loadPlayerClass: async (_ref) => {
       throw new Error('Player class loading is not required for scenario bundle construction')
+    },
+    loadChallengeModifier: async (_ref) => {
+      throw new Error('Challenge modifier loading is not required for scenario bundle construction')
     }
   }
 }

--- a/tests/content/test_helpers.ts
+++ b/tests/content/test_helpers.ts
@@ -235,6 +235,9 @@ export function createMockContentProvider(): ContentProvider {
     },
     loadPlayerClass: async (_ref) => {
       throw new Error('Mock player class not implemented')
+    },
+    loadChallengeModifier: async (_ref) => {
+      throw new Error('Mock challenge modifier not implemented')
     }
   }
 }

--- a/tests/simulation/outcome_archetype_classification.test.ts
+++ b/tests/simulation/outcome_archetype_classification.test.ts
@@ -48,8 +48,8 @@ describe('Outcome archetype classification', () => {
     const archetype = classifyOutcomeArchetype({
       run_analytics: createAnalytics({
         cumulative_score_deltas: {
-          domain_clarity: 25,
-          maintainability: 15,
+          domain_clarity: 15,
+          maintainability: 10,
           delivery_confidence: -5,
           budget: -10
         },
@@ -85,8 +85,8 @@ describe('Outcome archetype classification', () => {
     const archetype = classifyOutcomeArchetype({
       run_analytics: createAnalytics({
         cumulative_score_deltas: {
-          domain_clarity: 25,
-          maintainability: 15,
+          domain_clarity: 15,
+          maintainability: 10,
           delivery_confidence: -25,
           budget: -20
         },
@@ -122,15 +122,15 @@ describe('Outcome archetype classification', () => {
         total_events_triggered: 1,
         total_aftershocks_resolved: 0,
         cumulative_score_deltas: {
-          domain_clarity: 4,
-          maintainability: 2,
-          delivery_confidence: 2,
-          budget: 1,
+          domain_clarity: 2,
+          maintainability: 1,
+          delivery_confidence: -2,
+          budget: -1,
           user_trust: 1
         },
         cumulative_stakeholder_deltas: {
-          cto: 2,
-          vp_product: 1
+          cto: -1,
+          vp_product: 0
         }
       })
     })
@@ -139,11 +139,11 @@ describe('Outcome archetype classification', () => {
   })
 
   it('boundary_builder vs runaway_refactorer depends on final delivery_confidence', () => {
-    // delivery_confidence at 30 (50 + (-20)) → boundary_builder
+    // delivery_confidence at 30 (50 + (-20)) → boundary_builder (arch delta = 25, < 30 so not visionary)
     const builder = classifyOutcomeArchetype({
       run_analytics: createAnalytics({
         cumulative_score_deltas: {
-          domain_clarity: 20,
+          domain_clarity: 15,
           maintainability: 10,
           delivery_confidence: -20,
           budget: -10
@@ -156,7 +156,7 @@ describe('Outcome archetype classification', () => {
     const refactorer = classifyOutcomeArchetype({
       run_analytics: createAnalytics({
         cumulative_score_deltas: {
-          domain_clarity: 20,
+          domain_clarity: 15,
           maintainability: 10,
           delivery_confidence: -21,
           budget: -10
@@ -178,8 +178,8 @@ describe('Outcome archetype classification', () => {
         },
         run_analytics: createAnalytics({
           cumulative_score_deltas: {
-            domain_clarity: 30,
-            maintainability: 20,
+            domain_clarity: 20,
+            maintainability: 8,
             delivery_confidence: -5,
             budget: -5
           }
@@ -187,7 +187,7 @@ describe('Outcome archetype classification', () => {
       }
     })
 
-    // Final delivery_confidence from scores is 20 < 30 → runaway_refactorer
+    // arch delta = 28 (< 30, so not visionary), delivery 20 < 30 → runaway_refactorer
     expect(archetype).toBe('runaway_refactorer')
   })
 
@@ -248,7 +248,12 @@ describe('Outcome archetype classification', () => {
         'stakeholder_whisperer',
         'runaway_refactorer',
         'firefighter',
-        'system_stabilizer'
+        'system_stabilizer',
+        'the_diplomat',
+        'budget_hawk',
+        'the_pragmatist',
+        'the_visionary',
+        'burnout_machine'
       ]
     ).toContain(archetype)
   })
@@ -278,8 +283,8 @@ describe('Outcome archetype classification', () => {
       budget: 40
     }
     gameState.run_analytics.cumulative_score_deltas = {
-      domain_clarity: 25,
-      maintainability: 15,
+      domain_clarity: 15,
+      maintainability: 10,
       delivery_confidence: -5,
       budget: -10
     }

--- a/tests/simulation/stakeholder_state_diagnosis.test.ts
+++ b/tests/simulation/stakeholder_state_diagnosis.test.ts
@@ -15,19 +15,7 @@ import {
   OutcomeTier,
   OutcomeArchetype
 } from '@/domains/content/model'
-
-interface ContentProvider {
-  loadScenario(ref: VersionRef): Promise<Scenario>
-  loadScore(ref: VersionRef): Promise<Score>
-  loadStakeholder(ref: VersionRef): Promise<Stakeholder>
-  loadStakeholderReactionRule(ref: VersionRef): Promise<StakeholderReactionRule>
-  loadCard(ref: VersionRef): Promise<Card>
-  loadEvent(ref: VersionRef): Promise<Event>
-  loadDelayedEffect(ref: VersionRef): Promise<DelayedEffect>
-  loadOutcomeTier(ref: VersionRef): Promise<OutcomeTier>
-  loadOutcomeArchetype(ref: VersionRef): Promise<OutcomeArchetype>
-  loadPlayerClass(): Promise<never>
-}
+import { ContentProvider } from '@/domains/content/services/content_provider'
 
 /**
  * Diagnostic tests for stakeholder state behavior
@@ -67,6 +55,9 @@ function createFileContentProvider(contentRoot: string): ContentProvider {
     loadOutcomeArchetype: (ref: VersionRef) => loadJson<OutcomeArchetype>('outcome-archetypes', ref),
     loadPlayerClass: async () => {
       throw new Error('Player class loading is not required for scenario bundle construction')
+    },
+    loadChallengeModifier: async () => {
+      throw new Error('Challenge modifier loading is not required for scenario bundle construction')
     }
   }
 }

--- a/tests/ui/game_store_orchestration.test.ts
+++ b/tests/ui/game_store_orchestration.test.ts
@@ -44,6 +44,7 @@ vi.mock('@/domains/content/services/manifest_loader', () => {
       { id: 'boundary_mage', version: 1 },
       { id: 'stakeholder_bard', version: 1 },
     ],
+    challenge_modifiers: [],
     tutorials: [],
     content: {
       scenarios: [
@@ -61,6 +62,7 @@ vi.mock('@/domains/content/services/manifest_loader', () => {
       outcome_tiers: [],
       outcome_archetypes: [],
       classes: ['boundary_mage-v1.json', 'stakeholder_bard-v1.json'],
+      challenge_modifiers: [],
     },
   }
 
@@ -75,6 +77,7 @@ vi.mock('@/domains/content/services/manifest_loader', () => {
     authors: [{ name: 'Test Author' }],
     scenarios: [],
     classes: [],
+    challenge_modifiers: [],
     tutorials: [
       { id: 'tutorial_basics', version: 1 },
       { id: 'tutorial_systems_under_pressure', version: 1 },
@@ -90,6 +93,7 @@ vi.mock('@/domains/content/services/manifest_loader', () => {
       outcome_tiers: [],
       outcome_archetypes: [],
       classes: [],
+      challenge_modifiers: [],
     },
   }
 


### PR DESCRIPTION
## Summary

Major content expansion and engine features to make the game meaningfully different across repeat playthroughs. Adds 60+ new content files, 3 engine systems, and a new scenario.

## Content Expansion

- **14 new events** — doubles the pool from 12 to 26; adds positive, scenario-specific, conditional, and mixed-outcome events. Each scenario now draws from a curated pool of shared + scenario-flavored events
- **8 new stakeholder reaction rules** — rebalances positive/negative ratio from 7/13 to ~15/15, adding recovery-path rules for each stakeholder
- **5 new outcome archetypes** — The Diplomat, Budget Hawk, Pragmatist, Visionary, and Burnout Machine reward distinct play styles
- **8 new action cards** — tradeoff-heavy cards with stakeholder-specific effects (e.g., Sunset Legacy Feature, Shadow IT Consolidation, Platform Team Formation)
- **New stakeholder**: Integration Program Manager (for merger scenario)
- **New delayed effects** tied to new events and cards

## New Scenario: The Merger of Minor Chaos

Two mid-size companies merging tech stacks — reconcile duplicate systems, competing domain models, and culture clashes. Includes 5 merger-specific events, 3 merger-specific cards, and the Integration Program Manager stakeholder.

## Engine Features

- **Class abilities** — each class now has a `score_affinity` that grants +1 to its affinity score on every action card played (action phase only)
- **Score variance** — scenarios declare `score_variance: 5`, applying ±5 seeded random jitter to starting scores for different openings each run
- **Challenge modifiers** — 4 optional difficulty modifiers (Hard Mode, Budget Crisis, Speed Run, Stakeholder Revolt) applied at run creation. New content type with manifest registration and full validation

## UI Changes

- Challenge modifier selection chips on the run setup screen
- Scenario name pill in the game header (clickable → modal with scenario description)

## Balance

All 5 scenarios verified within 25–75% win rate band (200 runs each):

| Scenario | Win Rate |
|----------|----------|
| Monolith of Mild Despair | 63% |
| Compliance Gauntlet | 73% |
| Microservice Sprawl | 59% |
| Startup Hypergrowth | 69.5% |
| Merger of Minor Chaos | 60.5% |

- Positive reaction rule feedback loop identified and fixed (raised thresholds +15, reduced team_morale deltas)
- All challenge modifiers verified to have meaningful impact
- Score variance confirmed safe (0 unwinnable starts across 700 checks)
- Determinism verified (identical seed replay)
- Audit gate: PASSED (0 critical)

## Bug Fixes

- Fixed challenge modifiers not appearing in UI (tutorial manifest missing `challenge_modifiers` field; validator not checking for it)
- Fixed Stakeholder Revolt modifier having zero effect (added `score_adjustments`)
- Softened Hard Mode from -10 to -7 per score (was too punishing at -57% win rate shift)

## Test Status

470/470 passing